### PR TITLE
[REFACTOR] ArticleCategory, Challenge, Bookmark Factory Pattern 적용(#143)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		C00780BA2A60149D0043EB36 /* LHTodayArticleTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00780B92A60149D0043EB36 /* LHTodayArticleTitle.swift */; };
 		C009E9EE2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */; };
 		C009E9F02ADBC08A00112F18 /* ArticleCategortFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */; };
+		C009E9F22ADBC23B00112F18 /* ChallengeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F12ADBC23B00112F18 /* ChallengeFactory.swift */; };
+		C009E9F42ADBC24A00112F18 /* ChallengeFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */; };
 		C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381A2A65346700B00600 /* UserDefaultToken.swift */; };
 		C06E381D2A65348A00B00600 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381C2A65348A00B00600 /* LoginRequest.swift */; };
 		C06E38212A65351600B00600 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E38202A65351600B00600 /* SignUpRequest.swift */; };
@@ -411,6 +413,8 @@
 		C00780B92A60149D0043EB36 /* LHTodayArticleTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LHTodayArticleTitle.swift; sourceTree = "<group>"; };
 		C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategortFactoryImpl.swift; sourceTree = "<group>"; };
 		C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategortFactory.swift; sourceTree = "<group>"; };
+		C009E9F12ADBC23B00112F18 /* ChallengeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeFactory.swift; sourceTree = "<group>"; };
+		C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeFactoryImpl.swift; sourceTree = "<group>"; };
 		C06E381A2A65346700B00600 /* UserDefaultToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultToken.swift; sourceTree = "<group>"; };
 		C06E381C2A65348A00B00600 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		C06E38202A65351600B00600 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
@@ -1336,6 +1340,7 @@
 			isa = PBXGroup;
 			children = (
 				C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */,
+				C009E9F12ADBC23B00112F18 /* ChallengeFactory.swift */,
 			);
 			path = FactoryInterface;
 			sourceTree = "<group>";
@@ -1344,6 +1349,7 @@
 			isa = PBXGroup;
 			children = (
 				C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */,
+				C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */,
 			);
 			path = FactoryImpl;
 			sourceTree = "<group>";
@@ -1777,6 +1783,7 @@
 				C0DF03A62A5CB8610037F740 /* CompleteOnbardingViewController.swift in Sources */,
 				C003CC372AD923D100AFFAAC /* ExpireNavigation.swift in Sources */,
 				C0DF034B2A5A9B6A0037F740 /* CurriculumViewController.swift in Sources */,
+				C009E9F42ADBC24A00112F18 /* ChallengeFactoryImpl.swift in Sources */,
 				F435E0542A5E67BF0098E691 /* NSObject+.swift in Sources */,
 				4AE19A1F2A66F2E200C1DB7E /* BookmarkDetailCollectionViewCell.swift in Sources */,
 				D3AB54B62A625A7B0017BF53 /* ArticleListByCategoryHeaderView.swift in Sources */,
@@ -1891,6 +1898,7 @@
 				C003CC352AD923AF00AFFAAC /* BarNavigation.swift in Sources */,
 				C003CC6C2ADA51D100AFFAAC /* CurriculumManager.swift in Sources */,
 				4A8980CA2A614F8700746C58 /* MyPageModel.swift in Sources */,
+				C009E9F22ADBC23B00112F18 /* ChallengeFactory.swift in Sources */,
 				4A8980C52A611EE200746C58 /* MyPageProfileCollectionViewCell.swift in Sources */,
 				D3BA0B742A5CFA7B00B6361F /* ArticleCategoryModel.swift in Sources */,
 				C0DF033F2A5A959A0037F740 /* UIButton+.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		C003CC702ADA51F300AFFAAC /* ChallengeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC6F2ADA51F300AFFAAC /* ChallengeManager.swift */; };
 		C00780B72A5FFE0E0043EB36 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00780B62A5FFE0E0043EB36 /* UILabel+.swift */; };
 		C00780BA2A60149D0043EB36 /* LHTodayArticleTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00780B92A60149D0043EB36 /* LHTodayArticleTitle.swift */; };
+		C009E9EE2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */; };
+		C009E9F02ADBC08A00112F18 /* ArticleCategortFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */; };
 		C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381A2A65346700B00600 /* UserDefaultToken.swift */; };
 		C06E381D2A65348A00B00600 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381C2A65348A00B00600 /* LoginRequest.swift */; };
 		C06E38212A65351600B00600 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E38202A65351600B00600 /* SignUpRequest.swift */; };
@@ -407,6 +409,8 @@
 		C003CC6F2ADA51F300AFFAAC /* ChallengeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeManager.swift; sourceTree = "<group>"; };
 		C00780B62A5FFE0E0043EB36 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		C00780B92A60149D0043EB36 /* LHTodayArticleTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LHTodayArticleTitle.swift; sourceTree = "<group>"; };
+		C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategortFactoryImpl.swift; sourceTree = "<group>"; };
+		C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategortFactory.swift; sourceTree = "<group>"; };
 		C06E381A2A65346700B00600 /* UserDefaultToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultToken.swift; sourceTree = "<group>"; };
 		C06E381C2A65348A00B00600 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		C06E38202A65351600B00600 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
@@ -871,6 +875,7 @@
 			isa = PBXGroup;
 			children = (
 				C003CC322AD9237F00AFFAAC /* NavigationInterface */,
+				C009E9EA2ADBBB7B00112F18 /* Factory */,
 				C003CC192AD9175700AFFAAC /* Coordinator */,
 				C0DF03822A5AF7A20037F740 /* Challenge */,
 				B598920F2A56B44200CE1FEB /* Curriculum */,
@@ -1316,6 +1321,31 @@
 				C00780B92A60149D0043EB36 /* LHTodayArticleTitle.swift */,
 			);
 			path = Component;
+			sourceTree = "<group>";
+		};
+		C009E9EA2ADBBB7B00112F18 /* Factory */ = {
+			isa = PBXGroup;
+			children = (
+				C009E9EC2ADBBBA900112F18 /* FactoryImpl */,
+				C009E9EB2ADBBB9800112F18 /* FactoryInterface */,
+			);
+			path = Factory;
+			sourceTree = "<group>";
+		};
+		C009E9EB2ADBBB9800112F18 /* FactoryInterface */ = {
+			isa = PBXGroup;
+			children = (
+				C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */,
+			);
+			path = FactoryInterface;
+			sourceTree = "<group>";
+		};
+		C009E9EC2ADBBBA900112F18 /* FactoryImpl */ = {
+			isa = PBXGroup;
+			children = (
+				C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */,
+			);
+			path = FactoryImpl;
 			sourceTree = "<group>";
 		};
 		C06E381E2A6534E100B00600 /* UserDefault */ = {
@@ -1838,6 +1868,7 @@
 				C0DF032B2A5A918F0037F740 /* TableViewCellRegisterDequeueProtocol.swift in Sources */,
 				C003CC5C2ADA506800AFFAAC /* SplashManager.swift in Sources */,
 				B51220642A6039AA006CBE2D /* HttpMethod.swift in Sources */,
+				C009E9F02ADBC08A00112F18 /* ArticleCategortFactory.swift in Sources */,
 				C003CC1D2AD917CF00AFFAAC /* AppCoordinator.swift in Sources */,
 				B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */,
 				C0856B872ABFD24E0026D9F8 /* CurriculumListManagerImpl.swift in Sources */,
@@ -1901,6 +1932,7 @@
 				C00780BA2A60149D0043EB36 /* LHTodayArticleTitle.swift in Sources */,
 				B51220602A60111C006CBE2D /* Token.swift in Sources */,
 				C003CC702ADA51F300AFFAAC /* ChallengeManager.swift in Sources */,
+				C009E9EE2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift in Sources */,
 				B5C6A2C82A5EF4EB0021BE5E /* ArticleDetail.swift in Sources */,
 				C0DF03312A5A92730037F740 /* CollectionViewCellRegisterDequeueProtocol.swift in Sources */,
 				C06E381D2A65348A00B00600 /* LoginRequest.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		C009E9F02ADBC08A00112F18 /* ArticleCategortFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */; };
 		C009E9F22ADBC23B00112F18 /* ChallengeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F12ADBC23B00112F18 /* ChallengeFactory.swift */; };
 		C009E9F42ADBC24A00112F18 /* ChallengeFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */; };
+		C009E9F62ADBC41D00112F18 /* BookmarkFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F52ADBC41D00112F18 /* BookmarkFactory.swift */; };
+		C009E9F82ADBC43300112F18 /* BookmarkFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F72ADBC43300112F18 /* BookmarkFactoryImpl.swift */; };
 		C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381A2A65346700B00600 /* UserDefaultToken.swift */; };
 		C06E381D2A65348A00B00600 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381C2A65348A00B00600 /* LoginRequest.swift */; };
 		C06E38212A65351600B00600 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E38202A65351600B00600 /* SignUpRequest.swift */; };
@@ -415,6 +417,8 @@
 		C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategortFactory.swift; sourceTree = "<group>"; };
 		C009E9F12ADBC23B00112F18 /* ChallengeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeFactory.swift; sourceTree = "<group>"; };
 		C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeFactoryImpl.swift; sourceTree = "<group>"; };
+		C009E9F52ADBC41D00112F18 /* BookmarkFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFactory.swift; sourceTree = "<group>"; };
+		C009E9F72ADBC43300112F18 /* BookmarkFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFactoryImpl.swift; sourceTree = "<group>"; };
 		C06E381A2A65346700B00600 /* UserDefaultToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultToken.swift; sourceTree = "<group>"; };
 		C06E381C2A65348A00B00600 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		C06E38202A65351600B00600 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
@@ -1341,6 +1345,7 @@
 			children = (
 				C009E9EF2ADBC08A00112F18 /* ArticleCategortFactory.swift */,
 				C009E9F12ADBC23B00112F18 /* ChallengeFactory.swift */,
+				C009E9F52ADBC41D00112F18 /* BookmarkFactory.swift */,
 			);
 			path = FactoryInterface;
 			sourceTree = "<group>";
@@ -1350,6 +1355,7 @@
 			children = (
 				C009E9ED2ADBC07700112F18 /* ArticleCategortFactoryImpl.swift */,
 				C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */,
+				C009E9F72ADBC43300112F18 /* BookmarkFactoryImpl.swift */,
 			);
 			path = FactoryImpl;
 			sourceTree = "<group>";
@@ -1775,6 +1781,7 @@
 				C0F029CB2A5F034400E0D185 /* LHOnboardingButton.swift in Sources */,
 				B59893112A5D039B00CE1FEB /* ArticleBlockType.swift in Sources */,
 				C0DF03332A5A931B0037F740 /* UIView+.swift in Sources */,
+				C009E9F82ADBC43300112F18 /* BookmarkFactoryImpl.swift in Sources */,
 				B5C6A2BC2A5DE2A50021BE5E /* BodyTableViewCell.swift in Sources */,
 				C0DF03852A5AF7B70037F740 /* ChallengeViewController.swift in Sources */,
 				C09217692A605DEE00231C66 /* OnboardingPregnancyTextFieldResultType.swift in Sources */,
@@ -1955,6 +1962,7 @@
 				C0DF03412A5A95E40037F740 /* UIImage+.swift in Sources */,
 				C0F62FE72A691FC40003ADFA /* LHLoadingView.swift in Sources */,
 				C0B15E132AC010CD0058D56B /* LHKingfisherService.swift in Sources */,
+				C009E9F62ADBC41D00112F18 /* BookmarkFactory.swift in Sources */,
 				4A8980CE2A617F7100746C58 /* CollectionHeaderViewRegisterDequeueProtocol.swift in Sources */,
 				4A860AD62A6265B2002BA428 /* BookmarkModel.swift in Sources */,
 				B5C6A2BE2A5DE6590021BE5E /* GeneralTitleTableViewCell.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -146,6 +146,9 @@
 		C009E9F42ADBC24A00112F18 /* ChallengeFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */; };
 		C009E9F62ADBC41D00112F18 /* BookmarkFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F52ADBC41D00112F18 /* BookmarkFactory.swift */; };
 		C009E9F82ADBC43300112F18 /* BookmarkFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F72ADBC43300112F18 /* BookmarkFactoryImpl.swift */; };
+		C009E9FA2ADBC4DE00112F18 /* BookmarkViewControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9F92ADBC4DE00112F18 /* BookmarkViewControllerable.swift */; };
+		C009E9FC2ADBC4FD00112F18 /* ChallengeViewControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9FB2ADBC4FD00112F18 /* ChallengeViewControllerable.swift */; };
+		C009E9FE2ADBC51400112F18 /* ArticleCategoryViewControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C009E9FD2ADBC51400112F18 /* ArticleCategoryViewControllerable.swift */; };
 		C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381A2A65346700B00600 /* UserDefaultToken.swift */; };
 		C06E381D2A65348A00B00600 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E381C2A65348A00B00600 /* LoginRequest.swift */; };
 		C06E38212A65351600B00600 /* SignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E38202A65351600B00600 /* SignUpRequest.swift */; };
@@ -419,6 +422,9 @@
 		C009E9F32ADBC24A00112F18 /* ChallengeFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeFactoryImpl.swift; sourceTree = "<group>"; };
 		C009E9F52ADBC41D00112F18 /* BookmarkFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFactory.swift; sourceTree = "<group>"; };
 		C009E9F72ADBC43300112F18 /* BookmarkFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFactoryImpl.swift; sourceTree = "<group>"; };
+		C009E9F92ADBC4DE00112F18 /* BookmarkViewControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewControllerable.swift; sourceTree = "<group>"; };
+		C009E9FB2ADBC4FD00112F18 /* ChallengeViewControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeViewControllerable.swift; sourceTree = "<group>"; };
+		C009E9FD2ADBC51400112F18 /* ArticleCategoryViewControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryViewControllerable.swift; sourceTree = "<group>"; };
 		C06E381A2A65346700B00600 /* UserDefaultToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultToken.swift; sourceTree = "<group>"; };
 		C06E381C2A65348A00B00600 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		C06E38202A65351600B00600 /* SignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequest.swift; sourceTree = "<group>"; };
@@ -1210,6 +1216,9 @@
 			isa = PBXGroup;
 			children = (
 				B59BFD322ADBB621005D2D81 /* ViewControllerable.swift */,
+				C009E9F92ADBC4DE00112F18 /* BookmarkViewControllerable.swift */,
+				C009E9FB2ADBC4FD00112F18 /* ChallengeViewControllerable.swift */,
+				C009E9FD2ADBC51400112F18 /* ArticleCategoryViewControllerable.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -1786,6 +1795,7 @@
 				C0DF03852A5AF7B70037F740 /* ChallengeViewController.swift in Sources */,
 				C09217692A605DEE00231C66 /* OnboardingPregnancyTextFieldResultType.swift in Sources */,
 				C003CC412ADA4EE000AFFAAC /* CurriculumListByWeekNavigation.swift in Sources */,
+				C009E9FE2ADBC51400112F18 /* ArticleCategoryViewControllerable.swift in Sources */,
 				C003CC1B2AD9176B00AFFAAC /* Coordinator.swift in Sources */,
 				C0DF03A62A5CB8610037F740 /* CompleteOnbardingViewController.swift in Sources */,
 				C003CC372AD923D100AFFAAC /* ExpireNavigation.swift in Sources */,
@@ -1818,6 +1828,7 @@
 				B5F323E92A6A8F0000047869 /* CurriculumWeekBackgroundDummy.swift in Sources */,
 				C0DF039F2A5CABC10037F740 /* GetPregnancyViewController.swift in Sources */,
 				F4DB30BC2A61691F00413EB9 /* CurriculumArticleByWeekRowZeroTableViewCell.swift in Sources */,
+				C009E9FC2ADBC4FD00112F18 /* ChallengeViewControllerable.swift in Sources */,
 				C0DF039A2A5B908E0037F740 /* CGColor+.swift in Sources */,
 				C003CC662ADA518E00AFFAAC /* ArticleDetailManager.swift in Sources */,
 				4AD216402A69AC1E00C9F2F2 /* MyPageResponse.swift in Sources */,
@@ -1891,6 +1902,7 @@
 				C0856B7D2ABFCA330026D9F8 /* LoginMangerImpl.swift in Sources */,
 				C003CC252AD9184700AFFAAC /* TabbbarCoordinator.swift in Sources */,
 				C003CC3F2ADA4EC300AFFAAC /* CurriculumNavigation.swift in Sources */,
+				C009E9FA2ADBC4DE00112F18 /* BookmarkViewControllerable.swift in Sources */,
 				F435E04C2A5DA6A40098E691 /* CurriculumUserInfoView.swift in Sources */,
 				C003CC452ADA4F1E00AFFAAC /* ArticleListByCategoryNavigation.swift in Sources */,
 				4A8980C72A6146DA00746C58 /* MyPageCustomerServiceCollectionViewCell.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
@@ -10,9 +10,11 @@ import UIKit
 
 import SnapKit
 
+protocol ArticleCategoryViewControllerable where Self: UIViewController {
+    var coordinator: ArticleCategoryNavigation? {get set}
+}
 
-
-final class ArticleCategoryViewController: UIViewController {
+final class ArticleCategoryViewController: UIViewController, ArticleCategoryViewControllerable {
     
     weak var coordinator: ArticleCategoryNavigation?
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
@@ -10,10 +10,6 @@ import UIKit
 
 import SnapKit
 
-protocol ArticleCategoryViewControllerable where Self: UIViewController {
-    var coordinator: ArticleCategoryNavigation? {get set}
-}
-
 final class ArticleCategoryViewController: UIViewController, ArticleCategoryViewControllerable {
     
     weak var coordinator: ArticleCategoryNavigation?

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -10,7 +10,12 @@ import UIKit
 
 import SnapKit
 
-final class ArticleListByCategoryViewController: UIViewController {
+protocol ArticleListByCategoryViewControllerable where Self: UIViewController {
+    var coordinator: ArticleListByCategoryNavigation? { get set }
+    var categoryString: String? { get set }
+}
+
+final class ArticleListByCategoryViewController: UIViewController, ArticleListByCategoryViewControllerable {
     
     weak var coordinator: ArticleListByCategoryNavigation?
     private let manager: ArticleListByCategoryManager

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
@@ -10,7 +10,11 @@ import UIKit
 
 import SnapKit
 
-final class BookmarkViewController: UIViewController {
+protocol BookmarkViewControllerable where Self: UIViewController {
+    var coordinator: BookmarkNavigation? { get set }
+}
+
+final class BookmarkViewController: UIViewController, BookmarkViewControllerable {
     
     weak var coordinator: BookmarkNavigation?
     private let manager: BookmarkManager

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
@@ -10,10 +10,6 @@ import UIKit
 
 import SnapKit
 
-protocol BookmarkViewControllerable where Self: UIViewController {
-    var coordinator: BookmarkNavigation? { get set }
-}
-
 final class BookmarkViewController: UIViewController, BookmarkViewControllerable {
     
     weak var coordinator: BookmarkNavigation?

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
@@ -11,10 +11,6 @@ import UIKit
 import SnapKit
 import Lottie
 
-protocol ChallengeViewControllerable where Self: UIViewController {
-    var coordinator: ChallengeNavigation? { get set }
-}
-
 final class ChallengeViewController: UIViewController, ChallengeViewControllerable {
     
     weak var coordinator: ChallengeNavigation?

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
@@ -11,7 +11,11 @@ import UIKit
 import SnapKit
 import Lottie
 
-final class ChallengeViewController: UIViewController {
+protocol ChallengeViewControllerable where Self: UIViewController {
+    var coordinator: ChallengeNavigation? { get set }
+}
+
+final class ChallengeViewController: UIViewController, ChallengeViewControllerable {
     
     weak var coordinator: ChallengeNavigation?
     private var manager: ChallengeManager

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCategoryCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCategoryCoordinator.swift
@@ -10,12 +10,15 @@ import UIKit
 final class ArticleCategoryCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
     
+    private let factory: ArticleCategortFactory
+    
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: ArticleCategortFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +26,7 @@ final class ArticleCategoryCoordinator: Coordinator {
     }
     
     func showArticleCategoryViewController() {
-        let articleCategoryViewController = ArticleCategoryViewController()
+        let articleCategoryViewController = factory.makeArticleCategoryViewController()
         articleCategoryViewController.coordinator = self
         self.navigationController.pushViewController(articleCategoryViewController, animated: true)
     }
@@ -45,7 +48,7 @@ extension ArticleCategoryCoordinator: ArticleCategoryNavigation, ArticleListByCa
     }
     
     func articleListCellTapped(categoryName: String) {
-        let articleListbyCategoryViewController = ArticleListByCategoryViewController(manager: ArticleListByCategoryMangerImpl(articleService: ArticleServiceImpl(apiService: APIService()), bookmarkService: BookmarkServiceImpl(apiService: APIService())))
+        let articleListbyCategoryViewController = factory.makeArticleListByCategoryViewController()
         articleListbyCategoryViewController.categoryString = categoryName
         articleListbyCategoryViewController.coordinator = self
         self.navigationController.pushViewController(articleListbyCategoryViewController, animated: true)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCategoryCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCategoryCoordinator.swift
@@ -61,7 +61,8 @@ extension ArticleCategoryCoordinator: ArticleCategoryNavigation, ArticleListByCa
     }
     
     func navigationLeftButtonTapped() {
-        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController)
+        let bookmarkFactory = BookmarkFactoryImpl()
+        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController, factory: bookmarkFactory)
         bookmarkCoordinator.start()
         children.append(bookmarkCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/BookmarkCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/BookmarkCoordinator.swift
@@ -9,13 +9,15 @@ import UIKit
 
 final class BookmarkCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
+    private let factory: BookmarkFactory
     
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: BookmarkFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +25,7 @@ final class BookmarkCoordinator: Coordinator {
     }
     
     func showBookmarkViewController() {
-        let bookmarkViewController = BookmarkViewController(manager: BookmarkMangerImpl(bookmarkService: BookmarkServiceImpl(apiService: APIService())))
+        let bookmarkViewController = factory.makeBookmarkViewController()
         bookmarkViewController.coordinator = self
         self.navigationController.pushViewController(bookmarkViewController, animated: true)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ChallengeCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ChallengeCoordinator.swift
@@ -38,7 +38,8 @@ extension ChallengeCoordinator: ChallengeNavigation {
     }
     
     func navigationLeftButtonTapped() {
-        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController)
+        let bookmakrFactory = BookmarkFactoryImpl()
+        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController, factory: bookmakrFactory)
         bookmarkCoordinator.start()
         children.append(bookmarkCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ChallengeCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ChallengeCoordinator.swift
@@ -9,13 +9,14 @@ import UIKit
 
 final class ChallengeCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
-    
+    private let factory: ChallengeFactory
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: ChallengeFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +24,7 @@ final class ChallengeCoordinator: Coordinator {
     }
     
     func showChallengeViewController() {
-        let challengeViewController = ChallengeViewController(manager: ChallengeManagerImpl(challengeService: ChallengeServiceImpl(apiService: APIService())))
+        let challengeViewController = factory.makeChallengeViewController()
         challengeViewController.coordinator = self
         navigationController.pushViewController(challengeViewController, animated: true)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumCoordinator.swift
@@ -58,7 +58,8 @@ extension CurriculumCoordinator: CurriculumNavigation, CurriculumListByWeekNavig
     }
     
     func navigationLeftButtonTapped() {
-        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController)
+        let bookmarkFactory = BookmarkFactoryImpl()
+        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController, factory: bookmarkFactory)
         bookmarkCoordinator.start()
         children.append(bookmarkCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ArticleCategoryViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ArticleCategoryViewControllerable.swift
@@ -1,0 +1,12 @@
+//
+//  ArticleCategoryViewControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import UIKit
+
+protocol ArticleCategoryViewControllerable where Self: UIViewController {
+    var coordinator: ArticleCategoryNavigation? {get set}
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/BookmarkViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/BookmarkViewControllerable.swift
@@ -1,0 +1,12 @@
+//
+//  BookmarkViewControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import UIKit
+
+protocol BookmarkViewControllerable where Self: UIViewController {
+    var coordinator: BookmarkNavigation? { get set }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ChallengeViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ChallengeViewControllerable.swift
@@ -1,0 +1,12 @@
+//
+//  ChallengeViewControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import UIKit
+
+protocol ChallengeViewControllerable where Self: UIViewController {
+    var coordinator: ChallengeNavigation? { get set }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ViewControllerable.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 
-protocol ViewControllerable where Self: UIViewController {
-    var coordinator: Coordinator { get set }
-}
+protocol ViewControllerable {}
+extension UIViewController: ViewControllerable {}
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
@@ -31,7 +31,7 @@ final class TabbarCoordinator: Coordinator {
         todayNavigationController.tabBarItem = UITabBarItem(title: "투데이", image: .assetImage(.home), tag: 0)
         
         let articleCategoryNavigationController = UINavigationController()
-        let articleCategoryCoordinator = ArticleCategoryCoordinator(navigationController: articleCategoryNavigationController)
+        let articleCategoryCoordinator = ArticleCategoryCoordinator(navigationController: articleCategoryNavigationController, factory: ArticleCategortFactoryImpl())
         articleCategoryCoordinator.parentCoordinator = parentCoordinator
         articleCategoryNavigationController.tabBarItem = UITabBarItem(title: "탐색", image: .assetImage(.search), tag: 1)
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
@@ -41,7 +41,7 @@ final class TabbarCoordinator: Coordinator {
         curriculumCoordinator.parentCoordinator = parentCoordinator
         
         let challengeNavigationController = UINavigationController()
-        let challengeCoordinator = ChallengeCoordinator(navigationController: challengeNavigationController)
+        let challengeCoordinator = ChallengeCoordinator(navigationController: challengeNavigationController, factory: ChallengeFactoryImpl())
         challengeCoordinator.parentCoordinator = parentCoordinator
         challengeNavigationController.tabBarItem = UITabBarItem(title: "챌린지", image: .assetImage(.challenge), tag: 3)
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
@@ -46,7 +46,8 @@ extension TodayCoordinator: TodayNavigation {
     }
     
     func navigationLeftButtonTapped() {
-        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController)
+        let bookmarkFactory = BookmarkFactoryImpl()
+        let bookmarkCoordinator = BookmarkCoordinator(navigationController: navigationController, factory: bookmarkFactory)
         bookmarkCoordinator.start()
         children.append(bookmarkCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleCategortFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleCategortFactoryImpl.swift
@@ -1,0 +1,19 @@
+//
+//  ArticleCategortFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import Foundation
+
+struct ArticleCategortFactoryImpl: ArticleCategortFactory {
+    func makeArticleCategoryViewController() -> ArticleCategoryViewControllerable {
+        return ArticleCategoryViewController()
+    }
+    
+    func makeArticleListByCategoryViewController() -> ArticleListByCategoryViewControllerable {
+        let articleListbyCategoryViewController = ArticleListByCategoryViewController(manager: ArticleListByCategoryMangerImpl(articleService: ArticleServiceImpl(apiService: APIService()), bookmarkService: BookmarkServiceImpl(apiService: APIService())))
+        return articleListbyCategoryViewController
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/BookmarkFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/BookmarkFactoryImpl.swift
@@ -1,0 +1,14 @@
+//
+//  BookmarkFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import Foundation
+
+struct BookmarkFactoryImpl: BookmarkFactory {
+    func makeBookmarkViewController() -> BookmarkViewControllerable {
+        return BookmarkViewController(manager: BookmarkMangerImpl(bookmarkService: BookmarkServiceImpl(apiService: APIService())))
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ChallengeFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ChallengeFactoryImpl.swift
@@ -1,0 +1,14 @@
+//
+//  ChallengeFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import Foundation
+
+struct ChallengeFactoryImpl: ChallengeFactory {
+    func makeChallengeViewController() -> ChallengeViewControllerable {
+        return ChallengeViewController(manager: ChallengeManagerImpl(challengeService: ChallengeServiceImpl(apiService: APIService())))
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleCategortFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleCategortFactory.swift
@@ -1,0 +1,13 @@
+//
+//  ArticleCategortFactory.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import Foundation
+
+protocol ArticleCategortFactory {
+    func makeArticleCategoryViewController() -> ArticleCategoryViewControllerable
+    func makeArticleListByCategoryViewController() -> ArticleListByCategoryViewControllerable
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/BookmarkFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/BookmarkFactory.swift
@@ -1,0 +1,12 @@
+//
+//  BookmarkFactory.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import Foundation
+
+protocol BookmarkFactory {
+    func makeBookmarkViewController() -> BookmarkViewControllerable
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ChallengeFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ChallengeFactory.swift
@@ -1,0 +1,12 @@
+//
+//  ChallengeFactory.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/10/15.
+//
+
+import Foundation
+
+protocol ChallengeFactory {
+    func makeChallengeViewController() -> ChallengeViewControllerable
+}


### PR DESCRIPTION
## [#143] REFACTOR : ArticleCategory, Challenge, Bookmark Factory Pattern 적용

## 🌱 작업한 내용
- ArticleCategory관련 coordinator, viewcontroller에 factory pattern을 적용했습니다
- Challenge관련 coordinator, viewcontroller에 factory pattern을 적용했습니다
- Bookmark관련 coordinator, viewcontroller에 factory pattern을 적용했습니다

## 🌱 PR Point
1. viewcontroller는 각각의 unique한 viewcontrollerable을 가지고 있고 해당interface는 coordinator(각각의 navigation interface type)와 데이터전달이 필요한 경우엔 해당 데이터를 추상화하고 있습니다

```swift
protocol BookmarkViewControllerable where Self: UIViewController {
    var coordinator: BookmarkNavigation? { get set }
}
```
2. 각각의 coordinator는 unique한 factory interface를 가지고 있고 각각 필요한 viewcontrollerable타입을 return해줍니다
    - coordinator의 init에 factory의 구현체를 외부 주입해줍니다
```swift
protocol BookmarkFactory {
    func makeBookmarkViewController() -> BookmarkViewControllerable
}
```

3. 구현체(impl)는 저장속성이 없고 메서드만 호출하면되기때문에 struct로 구현햇습니다
```swift
struct BookmarkFactoryImpl: BookmarkFactory {
    func makeBookmarkViewController() -> BookmarkViewControllerable {
        return BookmarkViewController(manager: BookmarkMangerImpl(bookmarkService: BookmarkServiceImpl(apiService: APIService())))
    }
}
```


## 📮 관련 이슈

- Resolved: #143 
