### PR TITLE
[REFACTOR] Curriculum, MyPage, Article Coordinator에 Factory Pattern 적용 (#145)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		B532E86C2A5564DD00F0DB19 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E86B2A5564DD00F0DB19 /* Encodable+.swift */; };
 		B53881B62A6649D6002D166E /* motion_logo_final.json in Resources */ = {isa = PBXBuildFile; fileRef = B53881B52A6649D6002D166E /* motion_logo_final.json */; };
 		B53BA2022A68717B006F9BFB /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BA2012A68717B006F9BFB /* LoadingIndicator.swift */; };
+		B53F4EE32ADBC1A3001C5752 /* ArticleFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53F4EE22ADBC1A3001C5752 /* ArticleFactoryImpl.swift */; };
+		B53F4EE52ADBC23F001C5752 /* MyPageFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53F4EE42ADBC23F001C5752 /* MyPageFactoryImpl.swift */; };
+		B53F4EE72ADBC29F001C5752 /* CurriculumFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53F4EE62ADBC29F001C5752 /* CurriculumFactoryImpl.swift */; };
+		B53F4EE92ADBC44B001C5752 /* CurriculumArticleByWeekControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53F4EE82ADBC44B001C5752 /* CurriculumArticleByWeekControllerable.swift */; };
 		B57BEB612A60E97100D1727C /* NetworkErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57BEB602A60E97100D1727C /* NetworkErrorCode.swift */; };
 		B57BEB632A612DA100D1727C /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57BEB622A612DA100D1727C /* UserDefaultsManager.swift */; };
 		B57BEB652A6134B800D1727C /* setRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57BEB642A6134B800D1727C /* setRootViewController.swift */; };
@@ -86,6 +90,12 @@
 		B59893132A5D3A4D00CE1FEB /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59893122A5D3A4D00CE1FEB /* NetworkError.swift */; };
 		B59893162A5D40FC00CE1FEB /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = B59893152A5D40FC00CE1FEB /* Kingfisher */; };
 		B59BFD332ADBB621005D2D81 /* ViewControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD322ADBB621005D2D81 /* ViewControllerable.swift */; };
+		B59BFD352ADBBAE6005D2D81 /* CurriculumControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD342ADBBAE6005D2D81 /* CurriculumControllerable.swift */; };
+		B59BFD3D2ADBBEF8005D2D81 /* ArticleControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD3C2ADBBEF8005D2D81 /* ArticleControllerable.swift */; };
+		B59BFD3F2ADBBF2B005D2D81 /* CurriculumFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD3E2ADBBF2B005D2D81 /* CurriculumFactory.swift */; };
+		B59BFD412ADBBFB2005D2D81 /* MyPageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD402ADBBFB2005D2D81 /* MyPageFactory.swift */; };
+		B59BFD432ADBBFF5005D2D81 /* ArticleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD422ADBBFF5005D2D81 /* ArticleFactory.swift */; };
+		B59BFD452ADBC08D005D2D81 /* MyPageControllerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD442ADBC08D005D2D81 /* MyPageControllerable.swift */; };
 		B5C6A2B22A5DB0B10021BE5E /* ArticleDetailTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2B12A5DB0B10021BE5E /* ArticleDetailTableView.swift */; };
 		B5C6A2B42A5DB11A0021BE5E /* ThumnailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2B32A5DB11A0021BE5E /* ThumnailTableViewCell.swift */; };
 		B5C6A2B62A5DD5FE0021BE5E /* TitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2B52A5DD5FE0021BE5E /* TitleTableViewCell.swift */; };
@@ -330,6 +340,10 @@
 		B532E86B2A5564DD00F0DB19 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		B53881B52A6649D6002D166E /* motion_logo_final.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = motion_logo_final.json; sourceTree = "<group>"; };
 		B53BA2012A68717B006F9BFB /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
+		B53F4EE22ADBC1A3001C5752 /* ArticleFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleFactoryImpl.swift; sourceTree = "<group>"; };
+		B53F4EE42ADBC23F001C5752 /* MyPageFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageFactoryImpl.swift; sourceTree = "<group>"; };
+		B53F4EE62ADBC29F001C5752 /* CurriculumFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumFactoryImpl.swift; sourceTree = "<group>"; };
+		B53F4EE82ADBC44B001C5752 /* CurriculumArticleByWeekControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumArticleByWeekControllerable.swift; sourceTree = "<group>"; };
 		B57BEB602A60E97100D1727C /* NetworkErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorCode.swift; sourceTree = "<group>"; };
 		B57BEB622A612DA100D1727C /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		B57BEB642A6134B800D1727C /* setRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = setRootViewController.swift; sourceTree = "<group>"; };
@@ -353,6 +367,12 @@
 		B59893102A5D039B00CE1FEB /* ArticleBlockType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleBlockType.swift; sourceTree = "<group>"; };
 		B59893122A5D3A4D00CE1FEB /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		B59BFD322ADBB621005D2D81 /* ViewControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerable.swift; sourceTree = "<group>"; };
+		B59BFD342ADBBAE6005D2D81 /* CurriculumControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumControllerable.swift; sourceTree = "<group>"; };
+		B59BFD3C2ADBBEF8005D2D81 /* ArticleControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleControllerable.swift; sourceTree = "<group>"; };
+		B59BFD3E2ADBBF2B005D2D81 /* CurriculumFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumFactory.swift; sourceTree = "<group>"; };
+		B59BFD402ADBBFB2005D2D81 /* MyPageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageFactory.swift; sourceTree = "<group>"; };
+		B59BFD422ADBBFF5005D2D81 /* ArticleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleFactory.swift; sourceTree = "<group>"; };
+		B59BFD442ADBC08D005D2D81 /* MyPageControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageControllerable.swift; sourceTree = "<group>"; };
 		B5C6A2B12A5DB0B10021BE5E /* ArticleDetailTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailTableView.swift; sourceTree = "<group>"; };
 		B5C6A2B32A5DB11A0021BE5E /* ThumnailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumnailTableViewCell.swift; sourceTree = "<group>"; };
 		B5C6A2B52A5DD5FE0021BE5E /* TitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTableViewCell.swift; sourceTree = "<group>"; };
@@ -1197,6 +1217,9 @@
 			isa = PBXGroup;
 			children = (
 				B59BFD322ADBB621005D2D81 /* ViewControllerable.swift */,
+				B59BFD342ADBBAE6005D2D81 /* CurriculumControllerable.swift */,
+				B59BFD3C2ADBBEF8005D2D81 /* ArticleControllerable.swift */,
+				B53F4EE82ADBC44B001C5752 /* CurriculumArticleByWeekControllerable.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -1256,6 +1279,13 @@
 				C003CC2C2AD9189100AFFAAC /* BookmarkCoordinator.swift */,
 				C003CC2E2AD9189F00AFFAAC /* MypageCoordinator.swift */,
 				C003CC302AD918AB00AFFAAC /* ArticleCoordinator.swift */,
+				B59BFD3E2ADBBF2B005D2D81 /* CurriculumFactory.swift */,
+				B59BFD402ADBBFB2005D2D81 /* MyPageFactory.swift */,
+				B59BFD422ADBBFF5005D2D81 /* ArticleFactory.swift */,
+				B59BFD442ADBC08D005D2D81 /* MyPageControllerable.swift */,
+				B53F4EE22ADBC1A3001C5752 /* ArticleFactoryImpl.swift */,
+				B53F4EE42ADBC23F001C5752 /* MyPageFactoryImpl.swift */,
+				B53F4EE62ADBC29F001C5752 /* CurriculumFactoryImpl.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1734,6 +1764,7 @@
 				C0DF03A92A5CF0460037F740 /* UserOnboardingModel.swift in Sources */,
 				C0B15E212AC0450E0058D56B /* ArticleListTableView.swift in Sources */,
 				B5C6A2B42A5DB11A0021BE5E /* ThumnailTableViewCell.swift in Sources */,
+				B59BFD412ADBBFB2005D2D81 /* MyPageFactory.swift in Sources */,
 				C003CC312AD918AB00AFFAAC /* ArticleCoordinator.swift in Sources */,
 				C003CC472ADA4F3400AFFAAC /* ArticleCategoryNavigation.swift in Sources */,
 				C0F029CB2A5F034400E0D185 /* LHOnboardingButton.swift in Sources */,
@@ -1761,6 +1792,7 @@
 				B59892E52A5B109900CE1FEB /* ScreenUtils.swift in Sources */,
 				C0B15E2B2AC115F90058D56B /* LHView.swift in Sources */,
 				C0F029E82A5FB9EF00E0D185 /* RoundContainerView.swift in Sources */,
+				B59BFD3F2ADBBF2B005D2D81 /* CurriculumFactory.swift in Sources */,
 				B532E8652A5529F100F0DB19 /* BaseResponse.swift in Sources */,
 				F4DB30B82A612D2800413EB9 /* CurriculumArticleByWeekTableViewCell.swift in Sources */,
 				C0DF03452A5A9A910037F740 /* CurriculumTableViewCell.swift in Sources */,
@@ -1784,6 +1816,7 @@
 				C0DF03392A5A945D0037F740 /* UIViewController+.swift in Sources */,
 				C003CC532ADA4FC100AFFAAC /* LoginNavigation.swift in Sources */,
 				B512205A2A5FAA47006CBE2D /* ImageLiterals.swift in Sources */,
+				B53F4EE52ADBC23F001C5752 /* MyPageFactoryImpl.swift in Sources */,
 				B57BEB612A60E97100D1727C /* NetworkErrorCode.swift in Sources */,
 				C07CB81A2A62C54D000198CC /* TodayModel.swift in Sources */,
 				C06E38212A65351600B00600 /* SignUpRequest.swift in Sources */,
@@ -1809,6 +1842,7 @@
 				C0DF03A12A5CAC220037F740 /* GetFetalNicknameViewController.swift in Sources */,
 				C0856B852ABFD0F50026D9F8 /* CurriculumManagerImpl.swift in Sources */,
 				C0F029EA2A5FD32900E0D185 /* LHRoundButton.swift in Sources */,
+				B59BFD3D2ADBBEF8005D2D81 /* ArticleControllerable.swift in Sources */,
 				C0DF03812A5AF51C0037F740 /* Constant.swift in Sources */,
 				B59892942A57A93300CE1FEB /* Config.swift in Sources */,
 				4AD6AE1A2A68436B00A3D745 /* ArticleListByCategoryResponse.swift in Sources */,
@@ -1865,11 +1899,13 @@
 				C0DF033F2A5A959A0037F740 /* UIButton+.swift in Sources */,
 				C0B15E152AC011840058D56B /* LHLabel.swift in Sources */,
 				F4DB30B02A611C9700413EB9 /* CurriculumListByWeekData.swift in Sources */,
+				B53F4EE92ADBC44B001C5752 /* CurriculumArticleByWeekControllerable.swift in Sources */,
 				C0DF034D2A5A9B8D0037F740 /* (null) in Sources */,
 				C003CC3B2ADA4DA100AFFAAC /* DismissNavigation.swift in Sources */,
 				C003CC4B2ADA4F6300AFFAAC /* BookmarkNavigation.swift in Sources */,
 				C09A33222A62D46300B40770 /* LHToast.swift in Sources */,
 				C003CC572ADA4FEB00AFFAAC /* UserState.swift in Sources */,
+				B59BFD352ADBBAE6005D2D81 /* CurriculumControllerable.swift in Sources */,
 				B53BA2022A68717B006F9BFB /* LoadingIndicator.swift in Sources */,
 				C0856B7F2ABFCBF20026D9F8 /* ArticleListByCategoryMangerImpl.swift in Sources */,
 				C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */,
@@ -1892,14 +1928,17 @@
 				C0F029CD2A5F8D2F00E0D185 /* UIPageViewController+.swift in Sources */,
 				C003CC3D2ADA4EB300AFFAAC /* ChallengeNavigation.swift in Sources */,
 				C0B15E232AC100690058D56B /* LHStackView.swift in Sources */,
+				B59BFD432ADBBFF5005D2D81 /* ArticleFactory.swift in Sources */,
 				C0856B732ABFC3070026D9F8 /* BookmarkMangerImpl.swift in Sources */,
 				B57BEB632A612DA100D1727C /* UserDefaultsManager.swift in Sources */,
 				C0DF037B2A5A9CF30037F740 /* OnboardingViewController.swift in Sources */,
 				C09217682A605DEE00231C66 /* OnboardingFetalNicknameTextFieldResultType.swift in Sources */,
+				B59BFD452ADBC08D005D2D81 /* MyPageControllerable.swift in Sources */,
 				C0F62FCA2A67CDCE0003ADFA /* BookmarkDetailCollectionViewCell.swift in Sources */,
 				C0DF03592A5A9BF80037F740 /* ArticleCategoryViewController.swift in Sources */,
 				C00780BA2A60149D0043EB36 /* LHTodayArticleTitle.swift in Sources */,
 				B51220602A60111C006CBE2D /* Token.swift in Sources */,
+				B53F4EE32ADBC1A3001C5752 /* ArticleFactoryImpl.swift in Sources */,
 				C003CC702ADA51F300AFFAAC /* ChallengeManager.swift in Sources */,
 				B5C6A2C82A5EF4EB0021BE5E /* ArticleDetail.swift in Sources */,
 				C0DF03312A5A92730037F740 /* CollectionViewCellRegisterDequeueProtocol.swift in Sources */,
@@ -1924,6 +1963,7 @@
 				B59892E12A5AF39300CE1FEB /* LHNavigationBarView.swift in Sources */,
 				C0F029E62A5FB9E000E0D185 /* ContainerView.swift in Sources */,
 				C0856B712ABFC0FB0026D9F8 /* ChallengeManagerImpl.swift in Sources */,
+				B53F4EE72ADBC29F001C5752 /* CurriculumFactoryImpl.swift in Sources */,
 				C0DF03672A5A9C680037F740 /* ArticleDetailViewController.swift in Sources */,
 				C003CC392ADA4D9600AFFAAC /* PopNavigation.swift in Sources */,
 				C003CC4D2ADA4F7600AFFAAC /* TodayNavigation.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -10,12 +10,8 @@ import UIKit
 
 import SnapKit
 
-
-
-
-
-final class ArticleDetailViewController: UIViewController {
-
+final class ArticleDetailViewController: UIViewController, ArticleControllerable {
+    
     // MARK: - UI Components
     weak var coordinator: ArticleDetailModalNavigation?
     private let manager: ArticleDetailManager

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCategoryCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCategoryCoordinator.swift
@@ -32,7 +32,8 @@ final class ArticleCategoryCoordinator: Coordinator {
 extension ArticleCategoryCoordinator: ArticleCategoryNavigation, ArticleListByCategoryNavigation {
     func articleListByCategoryCellTapped(articleID: Int) {
         let articleCoordinator = ArticleCoordinator(
-            navigationController: navigationController,
+            navigationController: navigationController, 
+            factory: ArticleFactoryImpl(),
             articleId: articleID
         )
         articleCoordinator.parentCoordinator = self
@@ -52,7 +53,10 @@ extension ArticleCategoryCoordinator: ArticleCategoryNavigation, ArticleListByCa
     }
     
     func navigationRightButtonTapped() {
-        let mypageCoordinator = MypageCoordinator(navigationController: navigationController)
+        let mypageCoordinator = MypageCoordinator(
+            navigationController: navigationController,
+            factory: MyPageFactoryImpl()
+        )
         mypageCoordinator.start()
         children.append(mypageCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleCoordinator.swift
@@ -13,12 +13,15 @@ final class ArticleCoordinator: Coordinator {
     
     var articleId: Int
     
+    var factory: ArticleFactory
+    
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController, articleId: Int) {
+    init(navigationController: UINavigationController, factory: ArticleFactory, articleId: Int) {
         self.navigationController = navigationController
+        self.factory = factory
         self.articleId = articleId
     }
     
@@ -27,9 +30,9 @@ final class ArticleCoordinator: Coordinator {
     }
     
     func showArticleDetailViewController() {
-        let articleDetailViewController = ArticleDetailViewController(manager: ArticleDetailManagerImpl(articleService: ArticleServiceImpl(apiService: APIService()), bookmarkService: BookmarkServiceImpl(apiService: APIService())))
-        articleDetailViewController.coordinator = self
+        let articleDetailViewController = factory.makeArticleDetailViewController()
         articleDetailViewController.setArticleId(id: articleId)
+        articleDetailViewController.coordinator = self
         articleDetailViewController.isModalInPresentation = true
         articleDetailViewController.modalPresentationStyle = .fullScreen
         navigationController.present(articleDetailViewController, animated: true)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactory.swift
@@ -1,0 +1,8 @@
+//
+//  ArticleFactory.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactory.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+
+protocol ArticleFactory {
+    func makeArticleDetailViewController() -> ArticleControllerable
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactoryImpl.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+
+
+struct ArticleFactoryImpl: ArticleFactory {
+    func makeArticleDetailViewController() -> ArticleControllerable {
+        let apiService = APIService()
+        let bookmarkService = BookmarkServiceImpl(apiService: apiService)
+        let articleService = ArticleServiceImpl(apiService: apiService)
+        let manager = ArticleDetailManagerImpl(articleService: articleService,
+                                                            bookmarkService: bookmarkService)
+        let articleDetailViewController = ArticleDetailViewController(manager: manager)
+        return articleDetailViewController
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ArticleFactoryImpl.swift
@@ -1,0 +1,8 @@
+//
+//  ArticleFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/BookmarkCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/BookmarkCoordinator.swift
@@ -31,7 +31,10 @@ final class BookmarkCoordinator: Coordinator {
 
 extension BookmarkCoordinator: BookmarkNavigation {
     func bookmarkCellTapped(articleID: Int) {
-        let articleCoordinator = ArticleCoordinator(navigationController: navigationController, articleId: articleID)
+        let articleCoordinator = ArticleCoordinator(
+            navigationController: navigationController,
+            factory: ArticleFactoryImpl(),
+            articleId: articleID)
         articleCoordinator.start()
         children.append(articleCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ChallengeCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ChallengeCoordinator.swift
@@ -31,7 +31,8 @@ final class ChallengeCoordinator: Coordinator {
 
 extension ChallengeCoordinator: ChallengeNavigation {
     func navigationRightButtonTapped() {
-        let mypageCoordinator = MypageCoordinator(navigationController: navigationController)
+        let mypageCoordinator = MypageCoordinator(navigationController: navigationController,
+                                                  factory: MyPageFactoryImpl())
         mypageCoordinator.start()
         children.append(mypageCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumCoordinator.swift
@@ -10,12 +10,15 @@ import UIKit
 final class CurriculumCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
     
+    let factory: CurriculumFactory
+    
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: CurriculumFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -32,7 +35,8 @@ final class CurriculumCoordinator: Coordinator {
 extension CurriculumCoordinator: CurriculumNavigation, CurriculumListByWeekNavigation {
     func curriculumArticleListCellTapped(articleId: Int) {
         let articleCoordinator = ArticleCoordinator(
-            navigationController: navigationController,
+            navigationController: navigationController, 
+            factory: ArticleFactoryImpl(),
             articleId: articleId
         )
         articleCoordinator.parentCoordinator = self
@@ -45,14 +49,17 @@ extension CurriculumCoordinator: CurriculumNavigation, CurriculumListByWeekNavig
     }
     
     func articleListCellTapped(itemIndex: Int) {
-        let curriculumViewController = CurriculumListByWeekViewController(manager: CurriculumListManagerImpl(bookmarkService: BookmarkServiceImpl(apiService: APIService()), curriculumService: CurriculumServiceImpl(apiService: APIService())))
+        let curriculumViewController = factory.makeCurriculumListViewController()
         curriculumViewController.coordinator = self
-        curriculumViewController.weekToIndexPathItem = itemIndex
+        curriculumViewController.setWeekIndexPath(week: itemIndex)
         navigationController.pushViewController(curriculumViewController, animated: true)
     }
     
     func navigationRightButtonTapped() {
-        let mypageCoordinator = MypageCoordinator(navigationController: navigationController)
+        let mypageCoordinator = MypageCoordinator(
+            navigationController: navigationController,
+            factory: MyPageFactoryImpl()
+        )
         mypageCoordinator.start()
         children.append(mypageCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactory.swift
@@ -1,0 +1,8 @@
+//
+//  CurriculumFactory.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactory.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+
+protocol CurriculumFactory {
+    func makeCurriculumViewController() -> CurriculumControllerable
+    func makeCurriculumListViewController() -> CurriculumArticleByWeekControllerable
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactoryImpl.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+
+
+struct CurriculumFactoryImpl: CurriculumFactory {
+    func makeCurriculumListViewController() -> CurriculumArticleByWeekControllerable {
+        let apiService = APIService()
+        let curriculumService = CurriculumServiceImpl(apiService: apiService)
+        let bookmarkService = BookmarkServiceImpl(apiService: apiService)
+        let curriculumListManager = CurriculumListManagerImpl(bookmarkService: bookmarkService, curriculumService: curriculumService)
+        let curriculumListViewController = CurriculumListByWeekViewController(manager: curriculumListManager)
+        return curriculumListViewController
+    }
+    
+    func makeCurriculumViewController() -> CurriculumControllerable {
+        let apiService = APIService()
+        let curriculumService = CurriculumServiceImpl(apiService: apiService)
+        let manager = CurriculumManagerImpl(curriculumService: curriculumService)
+        let curriculumViewController = CurriculumViewController(manager: manager)
+        return curriculumViewController
+    }
+    
+    
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CurriculumFactoryImpl.swift
@@ -1,0 +1,8 @@
+//
+//  CurriculumFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ArticleControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ArticleControllerable.swift
@@ -1,0 +1,8 @@
+//
+//  ArticleControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ArticleControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ArticleControllerable.swift
@@ -5,4 +5,10 @@
 //  Created by 김민재 on 10/15/23.
 //
 
-import Foundation
+import UIKit
+
+
+protocol ArticleControllerable where Self: UIViewController {
+    func setArticleId(id: Int?)
+    var coordinator: ArticleDetailModalNavigation? { get set }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumArticleByWeekControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumArticleByWeekControllerable.swift
@@ -1,0 +1,8 @@
+//
+//  CurriculumArticleByWeekControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumArticleByWeekControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumArticleByWeekControllerable.swift
@@ -5,4 +5,10 @@
 //  Created by 김민재 on 10/15/23.
 //
 
-import Foundation
+import UIKit
+
+
+protocol CurriculumArticleByWeekControllerable where Self: UIViewController {
+    func setWeekIndexPath(week: Int)
+    var coordinator: CurriculumListByWeekNavigation? { get set }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumControllerable.swift
@@ -1,0 +1,14 @@
+//
+//  CurriculumControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation
+
+
+protocol CurriculumControllerable: ViewControllerable {
+    var articleId: Int { get set }
+    var itemIndex: Int { get set }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/CurriculumControllerable.swift
@@ -5,10 +5,11 @@
 //  Created by 김민재 on 10/15/23.
 //
 
-import Foundation
+import UIKit
 
 
-protocol CurriculumControllerable: ViewControllerable {
-    var articleId: Int { get set }
-    var itemIndex: Int { get set }
+protocol CurriculumControllerable where Self: UIViewController {
+    var coordinator: CurriculumNavigation? { get set }
 }
+
+

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ViewControllerable.swift
@@ -10,4 +10,4 @@ import UIKit
 
 protocol ViewControllerable {}
 
-extension UIViewController: ViewControllerable
+extension UIViewController: ViewControllerable {}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/Interface/ViewControllerable.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 
-protocol ViewControllerable where Self: UIViewController {
-    var coordinator: Coordinator { get set }
-}
+protocol ViewControllerable {}
 
+extension UIViewController: ViewControllerable

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageControllerable.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageControllerable.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageControllerable.swift
@@ -5,4 +5,7 @@
 //  Created by 김민재 on 10/15/23.
 //
 
-import Foundation
+import UIKit
+
+
+protocol MyPageControllerable where Self: UIViewController {}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageControllerable.swift
@@ -8,4 +8,6 @@
 import UIKit
 
 
-protocol MyPageControllerable where Self: UIViewController {}
+protocol MyPageControllerable where Self: UIViewController {
+    var coordinator: MyPageNavigation? { get set }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactory.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageFactory.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactory.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+
+protocol MyPageFactory {
+    func makeMyPageViewController() -> MyPageControllerable
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactoryImpl.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+
+struct MyPageFactoryImpl: MyPageFactory {
+    func makeMyPageViewController() -> MyPageControllerable {
+        let apiService = APIService()
+        let authService = AuthServiceImpl(apiService: apiService)
+        let myPageService = MyPageServiceImpl(apiService: apiService)
+        let manager = MyPageManagerImpl(mypageService: myPageService, authService: authService)
+        let myPageViewController = MyPageViewController(manager: manager)
+        return myPageViewController
+    }
+    
+    
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MyPageFactoryImpl.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 10/15/23.
+//
+
+import Foundation

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MypageCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/MypageCoordinator.swift
@@ -10,12 +10,15 @@ import UIKit
 final class MypageCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
     
+    let factory: MyPageFactory
+    
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: MyPageFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +26,7 @@ final class MypageCoordinator: Coordinator {
     }
     
     func showMypageViewController() {
-        let myPageViewController = MyPageViewController(manager: MyPageManagerImpl(mypageService: MyPageServiceImpl(apiService: APIService()), authService: AuthServiceImpl(apiService: APIService())))
+        let myPageViewController = factory.makeMyPageViewController()
         myPageViewController.coordinator = self
         self.navigationController.pushViewController(myPageViewController, animated: true)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
@@ -36,7 +36,10 @@ final class TabbarCoordinator: Coordinator {
         articleCategoryNavigationController.tabBarItem = UITabBarItem(title: "탐색", image: .assetImage(.search), tag: 1)
         
         let curriculumNavigationController = UINavigationController()
-        let curriculumCoordinator = CurriculumCoordinator(navigationController: curriculumNavigationController)
+        let curriculumCoordinator = CurriculumCoordinator(
+            navigationController: curriculumNavigationController,
+            factory: CurriculumFactoryImpl()
+        )
         curriculumNavigationController.tabBarItem = UITabBarItem(title: "커리큘럼", image: .assetImage(.curriculum), tag: 2)
         curriculumCoordinator.parentCoordinator = parentCoordinator
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
@@ -31,7 +31,8 @@ final class TodayCoordinator: Coordinator {
 extension TodayCoordinator: TodayNavigation {
     func todayArticleTapped(articleID: Int) {
         let articleCoordinator = ArticleCoordinator(
-            navigationController: navigationController,
+            navigationController: navigationController, 
+            factory: ArticleFactoryImpl(),
             articleId: articleID
         )
         articleCoordinator.parentCoordinator = self
@@ -40,7 +41,8 @@ extension TodayCoordinator: TodayNavigation {
     }
     
     func navigationRightButtonTapped() {
-        let mypageCoordinator = MypageCoordinator(navigationController: navigationController)
+        let mypageCoordinator = MypageCoordinator(navigationController: navigationController,
+                                                  factory: MyPageFactoryImpl())
         mypageCoordinator.start()
         children.append(mypageCoordinator)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 
 import SnapKit
 
-final class CurriculumListByWeekViewController: UIViewController {
-    
+final class CurriculumListByWeekViewController: UIViewController, CurriculumArticleByWeekControllerable {
+
     weak var coordinator: CurriculumListByWeekNavigation?
     
     private let manager: CurriculumListManager
@@ -19,7 +19,7 @@ final class CurriculumListByWeekViewController: UIViewController {
     private let curriculumListByWeekCollectionView = LHCollectionView(color: .background, scroll: false)
     private lazy var navigationBar = LHNavigationBarView(type: .curriculumByWeek, viewController: self)
     
-    var weekToIndexPathItem: Int = 0
+    private var weekToIndexPathItem: Int = 0
     var listByWeekDatas: CurriculumWeekData? {
         didSet {
             self.curriculumListByWeekCollectionView.reloadData()
@@ -68,6 +68,10 @@ final class CurriculumListByWeekViewController: UIViewController {
     
     deinit {
         removeNotificationCenter()
+    }
+    
+    func setWeekIndexPath(week: Int) {
+        self.weekToIndexPathItem = week
     }
 }
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 import SnapKit
 import Lottie
 
-final class CurriculumViewController: UIViewController, CurriculumTableViewToggleButtonTappedProtocol{
+final class CurriculumViewController: UIViewController, CurriculumControllerable  {
     
     weak var coordinator: CurriculumNavigation?
     private let manager: CurriculumManager
@@ -176,7 +176,9 @@ extension CurriculumViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         return curriculumViewDatas.count
     }
-    
+}
+
+extension CurriculumViewController: CurriculumTableViewToggleButtonTappedProtocol {
     func toggleButtonTapped(indexPath: IndexPath?) {
         self.isFirstPresented = false
         guard let indexPath  else { return }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-final class MyPageViewController: UIViewController {
+final class MyPageViewController: UIViewController, MyPageControllerable {
     
     weak var coordinator: MyPageNavigation?
     


### PR DESCRIPTION
## 🌱 작업한 내용

- Curriculum, MyPage, Article Coordinator에 객체 생성 책임을 분리하기 위해 Factory를 만들어 주입시켜주었습니다. 

## 🌱 PR Point
1. ViewController는 다른 ViewController에게 데이터 전달을 받을 수도 있어야하기 때문에 해당 메서드와 함께 coordinator(각 뷰컨마다의 navigation interface 타입)를 가지고 있습니다.
```swift
protocol ArticleControllerable where Self: UIViewController {
    func setArticleId(id: Int?)
    var coordinator: ArticleDetailModalNavigation? { get set }
}
```

2. 각각의 뷰컨은 Factory를 주입받기 위한 프로토콜을 가지고 있습니다. 이 때 Factory에서 리턴해주는 타입은 실제 객체의 타입이 아닌 프로토콜을 리턴함으로써 의존성을 분리시킵니다.
```swift
protocol ArticleFactory {
    func makeArticleDetailViewController() -> ArticleControllerable
}
```

3. Factory를 실제로 구현한 FactoryImpl는 어떠한 속성도 없이 메서드만 존재하기 때문에 struct로 구성하였습니다.
```swift
struct ArticleFactoryImpl: ArticleFactory {
    func makeArticleDetailViewController() -> ArticleControllerable {
        let apiService = APIService()
        let bookmarkService = BookmarkServiceImpl(apiService: apiService)
        let articleService = ArticleServiceImpl(apiService: apiService)
        let manager = ArticleDetailManagerImpl(articleService: articleService,
                                                            bookmarkService: bookmarkService)
        let articleDetailViewController = ArticleDetailViewController(manager: manager)
        return articleDetailViewController
    }
}
```

## 📮 관련 이슈

- Resolved: #145 
