### PR TITLE
[REFACTOR] - Auth, Splash, Today factory pattern 적용 (#144)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		4A2050152A5DCD1900C7AF3C /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2050142A5DCD1900C7AF3C /* UICollectionView+.swift */; };
 		4A3D72872A5D405C00A36189 /* BookmarkListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3D72862A5D405C00A36189 /* BookmarkListCollectionViewCell.swift */; };
+		4A52DD9B2ADBBF2C00858230 /* SpalshFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A52DD9A2ADBBF2C00858230 /* SpalshFactory.swift */; };
+		4A52DD9D2ADBBF4C00858230 /* TodayFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A52DD9C2ADBBF4C00858230 /* TodayFactory.swift */; };
+		4A52DD9F2ADBC0E500858230 /* AuthFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A52DD9E2ADBC0E500858230 /* AuthFactory.swift */; };
 		4A81C2912ACC7DC80056E815 /* UICollectionViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A81C2902ACC7DC80056E815 /* UICollectionViewCell+.swift */; };
 		4A860AD62A6265B2002BA428 /* BookmarkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A860AD52A6265B2002BA428 /* BookmarkModel.swift */; };
 		4A8980C52A611EE200746C58 /* MyPageProfileCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980C42A611EE200746C58 /* MyPageProfileCollectionViewCell.swift */; };
@@ -279,6 +282,9 @@
 /* Begin PBXFileReference section */
 		4A2050142A5DCD1900C7AF3C /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		4A3D72862A5D405C00A36189 /* BookmarkListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListCollectionViewCell.swift; sourceTree = "<group>"; };
+		4A52DD9A2ADBBF2C00858230 /* SpalshFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpalshFactory.swift; sourceTree = "<group>"; };
+		4A52DD9C2ADBBF4C00858230 /* TodayFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayFactory.swift; sourceTree = "<group>"; };
+		4A52DD9E2ADBC0E500858230 /* AuthFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFactory.swift; sourceTree = "<group>"; };
 		4A81C2902ACC7DC80056E815 /* UICollectionViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+.swift"; sourceTree = "<group>"; };
 		4A860AD52A6265B2002BA428 /* BookmarkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkModel.swift; sourceTree = "<group>"; };
 		4A8980C12A5FD6AF00746C58 /* BookmarkDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkDetailCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1256,6 +1262,9 @@
 				C003CC2C2AD9189100AFFAAC /* BookmarkCoordinator.swift */,
 				C003CC2E2AD9189F00AFFAAC /* MypageCoordinator.swift */,
 				C003CC302AD918AB00AFFAAC /* ArticleCoordinator.swift */,
+				4A52DD9E2ADBC0E500858230 /* AuthFactory.swift */,
+				4A52DD9A2ADBBF2C00858230 /* SpalshFactory.swift */,
+				4A52DD9C2ADBBF4C00858230 /* TodayFactory.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1877,7 +1886,9 @@
 				B5C6A2B82A5DDDFD0021BE5E /* EditorTableViewCell.swift in Sources */,
 				C0F029C72A5EFB9D00E0D185 /* LHProgressView.swift in Sources */,
 				B5C6A2BA2A5DE14E0021BE5E /* ChapterTitleTableViewCell.swift in Sources */,
+				4A52DD9D2ADBBF4C00858230 /* TodayFactory.swift in Sources */,
 				C0DF034D2A5A9B8D0037F740 /* (null) in Sources */,
+				4A52DD9B2ADBBF2C00858230 /* SpalshFactory.swift in Sources */,
 				4A81C2912ACC7DC80056E815 /* UICollectionViewCell+.swift in Sources */,
 				C003CC2D2AD9189100AFFAAC /* BookmarkCoordinator.swift in Sources */,
 				C0856B772ABFC4EA0026D9F8 /* MyPageServiceImpl.swift in Sources */,
@@ -1889,6 +1900,7 @@
 				D3BA0B712A5CFA2300B6361F /* ArticleCategoryCollectionViewCell.swift in Sources */,
 				C003CC212AD9181600AFFAAC /* TodayCoordinator.swift in Sources */,
 				B532E8342A5525C600F0DB19 /* SceneDelegate.swift in Sources */,
+				4A52DD9F2ADBC0E500858230 /* AuthFactory.swift in Sources */,
 				C0F029CD2A5F8D2F00E0D185 /* UIPageViewController+.swift in Sources */,
 				C003CC3D2ADA4EB300AFFAAC /* ChallengeNavigation.swift in Sources */,
 				C0B15E232AC100690058D56B /* LHStackView.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/AppCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/AppCoordinator.swift
@@ -23,7 +23,7 @@ final class AppCoordinator: Coordinator {
     }
     
     func startSplashCoordinator() {
-        let splashCoordinator = SplashCoordinator(navigationController: navigationController)
+        let splashCoordinator = SplashCoordinator(navigationController: navigationController, factory: SplashFactoryImpl())
         children.removeAll()
         splashCoordinator.parentCoordinator = self
         children.append(splashCoordinator)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/AuthCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/AuthCoordinator.swift
@@ -9,13 +9,15 @@ import UIKit
 
 final class AuthCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
+    private let factory: AuthFactory
     
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: AuthFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +25,7 @@ final class AuthCoordinator: Coordinator {
     }
     
     func showLogin() {
-        let loginViewController = LoginViewController(manager: LoginMangerImpl(authService: AuthServiceImpl(apiService: APIService())))
+        let loginViewController = factory.makeLoginViewController()
         loginViewController.coordinator = self
         self.navigationController.pushViewController(loginViewController, animated: true)
     }
@@ -37,7 +39,7 @@ extension AuthCoordinator: LoginNavigation, OnboardingNavigation, CompleteOnbard
     }
     
     func onboardingCompleted(data: UserOnboardingModel) {
-        let completeViewController = CompleteOnbardingViewController()
+        let completeViewController = factory.makeCompleteOnbardingViewController()
         completeViewController.coordinator = self
         completeViewController.userData = data
         self.navigationController.pushViewController(completeViewController, animated: true)
@@ -53,7 +55,7 @@ extension AuthCoordinator: LoginNavigation, OnboardingNavigation, CompleteOnbard
         case .verified:
             splashCoorinator?.showTabbar()
         case .nonVerified:
-            let onboardingViewController = OnboardingViewController(manager: OnboardingManagerImpl(authService: AuthServiceImpl(apiService: APIService())))
+            let onboardingViewController = factory.makeOnboardingViewController()
             onboardingViewController.setKakaoAccessToken(kakaoToken)
             onboardingViewController.coordinator = self
             self.navigationController.pushViewController(onboardingViewController, animated: true)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/AuthFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/AuthFactory.swift
@@ -1,0 +1,31 @@
+//
+//  AuthFactoryImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 황찬미 on 2023/10/15.
+//
+
+import Foundation
+
+protocol AuthFactory {
+    func makeLoginViewController() -> LoginViewControllerable
+    func makeCompleteOnbardingViewController() -> CompleteOnbardingViewControllerable
+    func makeOnboardingViewController() -> OnboardingViewControllerable
+}
+
+struct AuthFactoryImpl: AuthFactory {
+    func makeLoginViewController() -> LoginViewControllerable {
+        let loginViewController = LoginViewController(manager: LoginMangerImpl(authService: AuthServiceImpl(apiService: APIService())))
+        return loginViewController
+    }
+    
+    func makeCompleteOnbardingViewController() -> CompleteOnbardingViewControllerable {
+        let completeViewController = CompleteOnbardingViewController()
+        return completeViewController
+    }
+    
+    func makeOnboardingViewController() -> OnboardingViewControllerable {
+        let onboardingViewController = OnboardingViewController(manager: OnboardingManagerImpl(authService: AuthServiceImpl(apiService: APIService())))
+        return onboardingViewController
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SpalshFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SpalshFactory.swift
@@ -1,0 +1,18 @@
+//
+//  SpalshFactory.swift
+//  LionHeart-iOS
+//
+//  Created by 황찬미 on 2023/10/15.
+//
+
+import UIKit
+
+protocol SplashFactory {
+    func makeSplashFactory() -> SplashViewControllerable
+}
+
+struct SplashFactoryImpl: SplashFactory {
+    func makeSplashFactory() -> SplashViewControllerable {
+        return SplashViewController(manager: SplashManagerImpl(authService: AuthServiceImpl(apiService: APIService())))
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SpalshFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SpalshFactory.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 protocol SplashFactory {
-    func makeSplashFactory() -> SplashViewControllerable
+    func makeSplashViewController() -> SplashViewControllerable
 }
 
 struct SplashFactoryImpl: SplashFactory {
-    func makeSplashFactory() -> SplashViewControllerable {
+    func makeSplashViewController() -> SplashViewControllerable {
         return SplashViewController(manager: SplashManagerImpl(authService: AuthServiceImpl(apiService: APIService())))
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SplashCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SplashCoordinator.swift
@@ -8,14 +8,17 @@
 import UIKit
 
 final class SplashCoordinator: Coordinator {
+    
     weak var parentCoordinator: Coordinator?
+    private let factory: SplashFactory
     
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: SplashFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +26,7 @@ final class SplashCoordinator: Coordinator {
     }
     
     func showSplashViewController() {
-        let splashViewController = SplashViewController(manager: SplashManagerImpl(authService: AuthServiceImpl(apiService: APIService())))
+        let splashViewController = factory.makeSplashFactory()
         splashViewController.coordinator = self
         self.navigationController.pushViewController(splashViewController, animated: false)
     }
@@ -36,7 +39,7 @@ final class SplashCoordinator: Coordinator {
     }
     
     func showLogin() {
-        let authCoordinator = AuthCoordinator(navigationController: navigationController)
+        let authCoordinator = AuthCoordinator(navigationController: navigationController, factory: AuthFactoryImpl())
         children.removeAll()
         authCoordinator.parentCoordinator = self
         children.append(authCoordinator)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SplashCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/SplashCoordinator.swift
@@ -26,7 +26,7 @@ final class SplashCoordinator: Coordinator {
     }
     
     func showSplashViewController() {
-        let splashViewController = factory.makeSplashFactory()
+        let splashViewController = factory.makeSplashViewController()
         splashViewController.coordinator = self
         self.navigationController.pushViewController(splashViewController, animated: false)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TabbbarCoordinator.swift
@@ -26,7 +26,7 @@ final class TabbarCoordinator: Coordinator {
         let tabbarController = TabBarViewController()
         
         let todayNavigationController = UINavigationController()
-        let todayCoordinator = TodayCoordinator(navigationController: todayNavigationController)
+        let todayCoordinator = TodayCoordinator(navigationController: todayNavigationController, factory: TodayFactoryImpl())
         todayCoordinator.parentCoordinator = parentCoordinator
         todayNavigationController.tabBarItem = UITabBarItem(title: "투데이", image: .assetImage(.home), tag: 0)
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
@@ -9,13 +9,15 @@ import UIKit
 
 final class TodayCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
+    private let factory: TodayFactory
     
     var children: [Coordinator] = []
     
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, factory: TodayFactory) {
         self.navigationController = navigationController
+        self.factory = factory
     }
     
     func start() {
@@ -23,7 +25,7 @@ final class TodayCoordinator: Coordinator {
     }
     
     func showTodayViewController() {
-        let todayViewController = TodayViewController(manager: TodayManagerImpl(articleService: ArticleServiceImpl(apiService: APIService())))
+        let todayViewController = factory.makeTodayFactory()
         todayViewController.coordinator = self
         self.navigationController.pushViewController(todayViewController, animated: true)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayCoordinator.swift
@@ -25,7 +25,7 @@ final class TodayCoordinator: Coordinator {
     }
     
     func showTodayViewController() {
-        let todayViewController = factory.makeTodayFactory()
+        let todayViewController = factory.makeTodayViewController()
         todayViewController.coordinator = self
         self.navigationController.pushViewController(todayViewController, animated: true)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayFactory.swift
@@ -1,0 +1,19 @@
+//
+//  TodayFactory.swift
+//  LionHeart-iOS
+//
+//  Created by 황찬미 on 2023/10/15.
+//
+
+import UIKit
+
+protocol TodayFactory {
+    func makeTodayFactory() -> TodayViewControllerable
+}
+
+struct TodayFactoryImpl: TodayFactory {
+    func makeTodayFactory() -> TodayViewControllerable {
+        return TodayViewController(manager: TodayManagerImpl(articleService: ArticleServiceImpl(apiService: APIService())))
+    }
+}
+

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/TodayFactory.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 protocol TodayFactory {
-    func makeTodayFactory() -> TodayViewControllerable
+    func makeTodayViewController() -> TodayViewControllerable
 }
 
 struct TodayFactoryImpl: TodayFactory {
-    func makeTodayFactory() -> TodayViewControllerable {
+    func makeTodayViewController() -> TodayViewControllerable {
         return TodayViewController(manager: TodayManagerImpl(articleService: ArticleServiceImpl(apiService: APIService())))
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Login/LoginViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Login/LoginViewController.swift
@@ -13,7 +13,12 @@ import SnapKit
 import KakaoSDKAuth
 import KakaoSDKUser
 
-final class LoginViewController: UIViewController {
+protocol LoginViewControllerable where Self: UIViewController {
+    var coordinator: LoginNavigation? { get set }
+}
+
+final class LoginViewController: UIViewController, LoginViewControllerable {
+    var userData: UserOnboardingModel?
     
     private var kakaoAccessToken: String? {
         didSet {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/CompleteOnbardingViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/CompleteOnbardingViewController.swift
@@ -10,7 +10,12 @@ import UIKit
 
 import SnapKit
 
-final class CompleteOnbardingViewController: UIViewController {
+protocol CompleteOnbardingViewControllerable where Self: UIViewController {
+    var coordinator: CompleteOnbardingNavigation? { get set }
+    var userData: UserOnboardingModel? { get set }
+}
+
+final class CompleteOnbardingViewController: UIViewController, CompleteOnbardingViewControllerable {
     
     private enum SizeInspector {
         static let sideOffset: CGFloat = 58

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -10,12 +10,12 @@ import UIKit
 
 import SnapKit
 
+protocol OnboardingViewControllerable where Self: UIViewController {
+    var coordinator: OnboardingNavigation? { get set }
+    func setKakaoAccessToken(_ token: String?)
+}
 
-
-
-
-final class OnboardingViewController: UIViewController {
-
+final class OnboardingViewController: UIViewController, OnboardingViewControllerable  {
     typealias OnboardingViews = [UIViewController]
     
     weak var coordinator: OnboardingNavigation?

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Splash/SplashViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Splash/SplashViewController.swift
@@ -10,7 +10,11 @@ import UIKit
 
 import SnapKit
 
-final class SplashViewController: UIViewController {
+protocol SplashViewControllerable where Self: UIViewController {
+    var coordinator: SplashNavigation? { get set }
+}
+
+final class SplashViewController: UIViewController, SplashViewControllerable {
 
     weak var coordinator: SplashNavigation?
     private let manager: SplashManager
@@ -50,6 +54,8 @@ final class SplashViewController: UIViewController {
         return UserDefaultsManager.tokenKey?.refreshToken
     }
 }
+
+extension SplashViewController: ViewControllerable { }
 
 private extension SplashViewController {
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -10,7 +10,11 @@ import UIKit
 
 import SnapKit
 
-final class TodayViewController: UIViewController {
+protocol TodayViewControllerable where Self: UIViewController {
+    var coordinator: TodayNavigation? { get set }
+}
+
+final class TodayViewController: UIViewController, TodayViewControllerable {
     
     weak var coordinator: TodayNavigation?
     private let manager: TodayManager


### PR DESCRIPTION
## 🌱 작업한 내용

- Auth, Splash, Today coordinator, viewcontroller에 factory pattern을 적용했습니다.

## 🌱 PR Point

1. 각각의 viewcontroller가 고유의 viewcontrollerable을 가지고 있어요. viewcontrollerable은 coordinator를 가지고 있고, 추가로 필요할 경우 데이터 전달 프로퍼티를 추상화하고 있어요.
```swift
protocol TodayViewControllerable where Self: UIViewController {
    var coordinator: TodayNavigation? { get set }
}
```

2. 각각의 cordinatory가 고유의 factory 프로토콜을 가지고 있고, 해당 viewcontrollerable 타입을 return 하고 있어요.
```swift
protocol TodayFactory {
    func makeTodayFactory() -> TodayViewControllerable
}
```

3. TodayFactoryImpl 구조체가 TodayFactory를 채택하여 필요한 로직을 구현해 주고 있습니다.
```swift
struct TodayFactoryImpl: TodayFactory {
    func makeTodayFactory() -> TodayViewControllerable {
        return TodayViewController(manager: TodayManagerImpl(articleService: ArticleServiceImpl(apiService: APIService())))
    }
}
```

## 📮 관련 이슈

- Resolved: #144 
