### PR TITLE
[REFACTOR] Adaptor Pattern 도입 (#153)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -118,11 +118,11 @@
 		B5C6A2C82A5EF4EB0021BE5E /* ArticleDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2C72A5EF4EB0021BE5E /* ArticleDetail.swift */; };
 		B5F323E92A6A8F0000047869 /* CurriculumWeekBackgroundDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F323E82A6A8F0000047869 /* CurriculumWeekBackgroundDummy.swift */; };
 		C003CC1B2AD9176B00AFFAAC /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC1A2AD9176B00AFFAAC /* Coordinator.swift */; };
-		C003CC1D2AD917CF00AFFAAC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC1C2AD917CF00AFFAAC /* AppCoordinator.swift */; };
+		C003CC1D2AD917CF00AFFAAC /* AppCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC1C2AD917CF00AFFAAC /* AppCoordinatorImpl.swift */; };
 		C003CC1F2AD917F900AFFAAC /* SplashCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC1E2AD917F900AFFAAC /* SplashCoordinatorImpl.swift */; };
 		C003CC212AD9181600AFFAAC /* TodayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC202AD9181600AFFAAC /* TodayCoordinator.swift */; };
 		C003CC232AD9183600AFFAAC /* AuthCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC222AD9183600AFFAAC /* AuthCoordinatorImpl.swift */; };
-		C003CC252AD9184700AFFAAC /* TabbbarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC242AD9184700AFFAAC /* TabbbarCoordinator.swift */; };
+		C003CC252AD9184700AFFAAC /* TabbarCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC242AD9184700AFFAAC /* TabbarCoordinatorImpl.swift */; };
 		C003CC272AD9185A00AFFAAC /* ArticleCategoryCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC262AD9185A00AFFAAC /* ArticleCategoryCoordinatorImpl.swift */; };
 		C003CC292AD9186B00AFFAAC /* CurriculumCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC282AD9186B00AFFAAC /* CurriculumCoordinator.swift */; };
 		C003CC2B2AD9187B00AFFAAC /* ChallengeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C003CC2A2AD9187B00AFFAAC /* ChallengeCoordinator.swift */; };
@@ -434,11 +434,11 @@
 		B5C6A2C72A5EF4EB0021BE5E /* ArticleDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetail.swift; sourceTree = "<group>"; };
 		B5F323E82A6A8F0000047869 /* CurriculumWeekBackgroundDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumWeekBackgroundDummy.swift; sourceTree = "<group>"; };
 		C003CC1A2AD9176B00AFFAAC /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
-		C003CC1C2AD917CF00AFFAAC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		C003CC1C2AD917CF00AFFAAC /* AppCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C003CC1E2AD917F900AFFAAC /* SplashCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C003CC202AD9181600AFFAAC /* TodayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCoordinator.swift; sourceTree = "<group>"; };
 		C003CC222AD9183600AFFAAC /* AuthCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorImpl.swift; sourceTree = "<group>"; };
-		C003CC242AD9184700AFFAAC /* TabbbarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbbarCoordinator.swift; sourceTree = "<group>"; };
+		C003CC242AD9184700AFFAAC /* TabbarCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C003CC262AD9185A00AFFAAC /* ArticleCategoryCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C003CC282AD9186B00AFFAAC /* CurriculumCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumCoordinator.swift; sourceTree = "<group>"; };
 		C003CC2A2AD9187B00AFFAAC /* ChallengeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeCoordinator.swift; sourceTree = "<group>"; };
@@ -1479,9 +1479,7 @@
 		C04BE3AA2ADD4F26001967B5 /* CoordinatorInterface */ = {
 			isa = PBXGroup;
 			children = (
-				C003CC1C2AD917CF00AFFAAC /* AppCoordinator.swift */,
 				C003CC202AD9181600AFFAAC /* TodayCoordinator.swift */,
-				C003CC242AD9184700AFFAAC /* TabbbarCoordinator.swift */,
 				C003CC282AD9186B00AFFAAC /* CurriculumCoordinator.swift */,
 				C003CC2A2AD9187B00AFFAAC /* ChallengeCoordinator.swift */,
 				C003CC2C2AD9189100AFFAAC /* BookmarkCoordinator.swift */,
@@ -1497,6 +1495,8 @@
 		C04BE3AB2ADD4F34001967B5 /* CoordinatorImpl */ = {
 			isa = PBXGroup;
 			children = (
+				C003CC1C2AD917CF00AFFAAC /* AppCoordinatorImpl.swift */,
+				C003CC242AD9184700AFFAAC /* TabbarCoordinatorImpl.swift */,
 				C003CC222AD9183600AFFAAC /* AuthCoordinatorImpl.swift */,
 				C04BE3AC2ADD4F5D001967B5 /* TodayCoordinatorImpl.swift */,
 				4A918E762AE10A89003CB8F9 /* MyPageCoordinatorImpl.swift */,
@@ -2056,13 +2056,13 @@
 				C003CC5C2ADA506800AFFAAC /* SplashManager.swift in Sources */,
 				B51220642A6039AA006CBE2D /* HttpMethod.swift in Sources */,
 				C009E9F02ADBC08A00112F18 /* ArticleCategortFactory.swift in Sources */,
-				C003CC1D2AD917CF00AFFAAC /* AppCoordinator.swift in Sources */,
+				C003CC1D2AD917CF00AFFAAC /* AppCoordinatorImpl.swift in Sources */,
 				B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */,
 				C0856B872ABFD24E0026D9F8 /* CurriculumListManagerImpl.swift in Sources */,
 				C003CC2B2AD9187B00AFFAAC /* ChallengeCoordinator.swift in Sources */,
 				C0F029DE2A5FAC6100E0D185 /* LHOnboardingTitleLabel.swift in Sources */,
 				C0856B7D2ABFCA330026D9F8 /* LoginMangerImpl.swift in Sources */,
-				C003CC252AD9184700AFFAAC /* TabbbarCoordinator.swift in Sources */,
+				C003CC252AD9184700AFFAAC /* TabbarCoordinatorImpl.swift in Sources */,
 				C003CC3F2ADA4EC300AFFAAC /* CurriculumNavigation.swift in Sources */,
 				C009E9FA2ADBC4DE00112F18 /* BookmarkViewControllerable.swift in Sources */,
 				F435E04C2A5DA6A40098E691 /* CurriculumUserInfoView.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Application/SceneDelegate.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Application/SceneDelegate.swift
@@ -13,7 +13,7 @@ import KakaoSDKAuth
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    var appCoordinator: AppCoordinator?
+    var appCoordinator: AppCoordinatorImpl?
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
@@ -34,8 +34,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         Font.registerFonts()
         
         let navigationController = UINavigationController()
-        appCoordinator = AppCoordinator(navigationController: navigationController)
-        appCoordinator?.start()
+        appCoordinator = AppCoordinatorImpl(navigationController: navigationController)
+        appCoordinator?.startSplashCoordinator()
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/LionHeart-iOS/LionHeart-iOS/Global/Protocols/Coordinator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Protocols/Coordinator.swift
@@ -11,8 +11,6 @@ protocol Coordinator : AnyObject {
     var parentCoordinator: Coordinator? { get set }
     var children: [Coordinator] { get set }
     var navigationController : UINavigationController { get set }
-    
-    func start()
 }
 
 extension Coordinator {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinatorImpl.swift
@@ -1,5 +1,5 @@
 //
-//  AppCoordinator.swift
+//  AppCoordinatorImpl.swift
 //  LionHeart-iOS
 //
 //  Created by uiskim on 2023/10/13.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class AppCoordinator: Coordinator {
+final class AppCoordinatorImpl: Coordinator {
     weak var parentCoordinator: Coordinator?
     
     var children: [Coordinator] = []
@@ -18,15 +18,11 @@ final class AppCoordinator: Coordinator {
         self.navigationController = navigationController
     }
     
-    func start() {
-        startSplashCoordinator()
-    }
-    
     func startSplashCoordinator() {
         let splashCoordinator = SplashCoordinatorImpl(navigationController: navigationController, factory: SplashFactoryImpl())
         children.removeAll()
         splashCoordinator.parentCoordinator = self
         children.append(splashCoordinator)
-        splashCoordinator.start()
+        splashCoordinator.showSplashViewController()
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCategoryCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCategoryCoordinatorImpl.swift
@@ -40,7 +40,7 @@ final class ArticleCategoryCoordinatorImpl: ArticleCategoryCoordinator {
         )
         articleCoordinator.parentCoordinator = self
         children.append(articleCoordinator)
-        articleCoordinator.start()
+        articleCoordinator.showArticleDetailViewController()
     }
     
     func showArticleListbyCategoryViewController(categoryName: String) {
@@ -52,7 +52,7 @@ final class ArticleCategoryCoordinatorImpl: ArticleCategoryCoordinator {
     func showBookmarkViewController() {
         let bookmarkFactory = BookmarkFactoryImpl()
         let bookmarkCoordinator = BookmarkCoordinatorImpl(navigationController: navigationController, factory: bookmarkFactory)
-        bookmarkCoordinator.start()
+        bookmarkCoordinator.showBookmarkViewController()
         children.append(bookmarkCoordinator)
     }
     
@@ -61,7 +61,7 @@ final class ArticleCategoryCoordinatorImpl: ArticleCategoryCoordinator {
             navigationController: navigationController,
             factory: MyPageFactoryImpl()
         )
-        mypageCoordinator.start()
+        mypageCoordinator.showMyPageViewController()
         children.append(mypageCoordinator)
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/BookmarkCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/BookmarkCoordinatorImpl.swift
@@ -35,7 +35,7 @@ final class BookmarkCoordinatorImpl: BookmarkCoordinator {
             navigationController: navigationController,
             factory: ArticleFactoryImpl(),
             articleId: articleId)
-        articleCoordinator.start()
+        articleCoordinator.showArticleDetailViewController()
         children.append(articleCoordinator)
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ChallengeCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ChallengeCoordinatorImpl.swift
@@ -33,14 +33,14 @@ final class ChallengeCoordinatorImpl: ChallengeCoordinator {
     func showMypageViewController() {
         let mypageCoordinator = MyPageCoordinatorImpl(navigationController: navigationController,
                                                   factory: MyPageFactoryImpl())
-        mypageCoordinator.start()
+        mypageCoordinator.showMyPageViewController()
         children.append(mypageCoordinator)
     }
     
     func showBookmarkViewController() {
         let bookmakrFactory = BookmarkFactoryImpl()
         let bookmarkCoordinator = BookmarkCoordinatorImpl(navigationController: navigationController, factory: bookmakrFactory)
-        bookmarkCoordinator.start()
+        bookmarkCoordinator.showBookmarkViewController()
         children.append(bookmarkCoordinator)
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/CurriculumCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/CurriculumCoordinatorImpl.swift
@@ -36,7 +36,7 @@ final class CurriculumCoordinatorImpl: CurriculumCoordinator {
         )
         articleCoordinator.parentCoordinator = self
         children.append(articleCoordinator)
-        articleCoordinator.start()
+        articleCoordinator.showArticleDetailViewController()
     }
     
     func showCurriculumListViewController(itemIndex: Int) {
@@ -50,14 +50,14 @@ final class CurriculumCoordinatorImpl: CurriculumCoordinator {
             navigationController: navigationController,
             factory: MyPageFactoryImpl()
         )
-        mypageCoordinator.start()
+        mypageCoordinator.showMyPageViewController()
         children.append(mypageCoordinator)
     }
     
     func showBookmarkViewController() {
         let bookmarkFactory = BookmarkFactoryImpl()
         let bookmarkCoordinator = BookmarkCoordinatorImpl(navigationController: navigationController, factory: bookmarkFactory)
-        bookmarkCoordinator.start()
+        bookmarkCoordinator.showBookmarkViewController()
         children.append(bookmarkCoordinator)
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
@@ -31,10 +31,10 @@ final class SplashCoordinatorImpl: SplashCoordinator {
     }
     
     func showTabbarViewContoller() {
-        let tabbarCoordinator = TabbarCoordinator(navigationController: navigationController)
+        let tabbarCoordinator = TabbarCoordinatorImpl(navigationController: navigationController)
         children.removeAll()
         tabbarCoordinator.parentCoordinator = self
-        tabbarCoordinator.start()
+        tabbarCoordinator.showTabbarController()
     }
     
     func showLoginViewController() {
@@ -42,6 +42,6 @@ final class SplashCoordinatorImpl: SplashCoordinator {
         children.removeAll()
         authCoordinator.parentCoordinator = self
         children.append(authCoordinator)
-        authCoordinator.start()
+        authCoordinator.showLoginViewController()
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TabbarCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TabbarCoordinatorImpl.swift
@@ -1,5 +1,5 @@
 //
-//  TabbbarCoordinator.swift
+//  TabbarCoordinatorImpl.swift
 //  LionHeart-iOS
 //
 //  Created by uiskim on 2023/10/13.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class TabbarCoordinator: Coordinator {
+final class TabbarCoordinatorImpl: Coordinator {
     weak var parentCoordinator: Coordinator?
     
     var children: [Coordinator] = []
@@ -55,9 +55,9 @@ final class TabbarCoordinator: Coordinator {
         navigationController.isNavigationBarHidden = true
         parentCoordinator?.children = [todayCoordinator, articleCategoryCoordinator, curriculumCoordinator, challengeCoordinator]
         
-        todayCoordinator.start()
-        articleCategoryCoordinator.start()
-        curriculumCoordinator.start()
-        challengeCoordinator.start()
+        todayCoordinator.showTodayViewController()
+        articleCategoryCoordinator.showArticleCategoryViewController()
+        curriculumCoordinator.showCurriculumViewController()
+        challengeCoordinator.showChallengeViewController()
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TodayCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TodayCoordinatorImpl.swift
@@ -37,20 +37,20 @@ final class TodayCoordinatorImpl: TodayCoordinator {
         )
         articleCoordinator.parentCoordinator = self
         children.append(articleCoordinator)
-        articleCoordinator.start()
+        articleCoordinator.showArticleDetailViewController()
     }
     
     func showMypageViewController() {
         let mypageCoordinator = MyPageCoordinatorImpl(navigationController: navigationController,
                                                   factory: MyPageFactoryImpl())
-        mypageCoordinator.start()
+        mypageCoordinator.showMyPageViewController()
         children.append(mypageCoordinator)
     }
     
     func showBookmarkViewController() {
         let bookmarkFactory = BookmarkFactoryImpl()
         let bookmarkCoordinator = BookmarkCoordinatorImpl(navigationController: navigationController, factory: bookmarkFactory)
-        bookmarkCoordinator.start()
+        bookmarkCoordinator.showBookmarkViewController()
         children.append(bookmarkCoordinator)
     }
     


### PR DESCRIPTION
## 🌱 작업한 내용

- Coordinator에 Adaptor 패턴을 도입했습니다.

## 🌱 PR Point

## Adaptor Pattern 도입 이유 🤔

> 외부에서 알필요가 없는 부분을 감춤으로써 대상을 단순화하는 추상화의 한종류를 우리는 캡슐화라고한다.
그중에서도 메서드명을 통해서 어떤 변수를 가지고 있는지 혹은 어떤 객체와 연관성을 가지는지를 노골적으로 public interface에 드러내는 것 또한 캡슐화에 위반된다.         -_오브젝트_-
> 

위의 글을 참고해서 최대한 interface에서 캡슐화를 위반하지 않기 위해 `ViewController`에서는 화면전환을 하기 위한 메서드명에 화면전환 flow를 노골적으로 드러내지 않게 하기 위해서 유추할 수 있는 정보(예를 들어 ViewController의 이름)를 모두 배제하고 action을 위주로 메서드명을 구성했습니다.

```swift
protocol BarNavigation: AnyObject {
    func navigationRightButtonTapped()
    func navigationLeftButtonTapped()
}

protocol ArticleCategoryNavigation: ExpireNavigation, BarNavigation {
    func articleListCellTapped(categoryName: String)
}
```


## 문제점 1.
```swift
extension ArticleCategoryCoordinator: ArticleCategoryNavigation, ArticleListByCategoryNavigation {
    func articleListCellTapped(categoryName: String) { ... }
    func navigationRightButtonTapped() { ... }
    func navigationLeftButtonTapped() { ... }
}
```
그러다보니 delgate로인해서 user의 action위주의 메서드를 가지고있는 Navigation interface를 `Coordinator`가 구현해줘야하는 상황이 생겼고 결론적으로 `Coordinator`가 user action관련 메서드명의 메서드를 가지게되어 위에서 언급한 캡슐화에도 위반되며 완전한 관심사 분리또한 불가능하게 되었습니다.

Coordinator는 어떤 ViewController를 보여줘야할지에 대한 flow에 대한 책임을 지니지만 **어떤 action**을 통해서 화면전환이 이루어지는에 대해서는 전혀 알 필요가 없고, 몰라야만 온전한 캡슐화가 가능해진다고 생각했습니다.

## 문제점 2.
두번째로 현재 `User Action` → `ViewController` → `Coordinator`순으로 layer의 depth가 깊어지는데 예를들어서 `ViewController`의 화면전환 flow가 변경되었을 때 ViewController는 변하지 않는데, 더 core한 depth에 있는 `Coordinator`에서 메서드의 내부 구현을 변경해야 되는 구조를 가지고 있습니다.

가장 중요도가 낮은 바깥쪽 레이어인 UI를 담당하는 ViewController가 변하지 않는데, 더 중요한 depth에 있는 Coordinator가 바뀌는 것을 옳지 않다고 생각했습니다.

## Adaptor 사용법
따라서 ViewController와 Coordinator 사이에 Adapter를 둠으로써 위 문제점들을 해결하고자 하였습니다.

<img width="1162" alt="image" src="https://github.com/Team-LionHeart/LionHeart-iOS/assets/60292150/b0b3f9a8-4120-4fed-a6d9-40bdc0472c4c">

- Coordinator내에서의 객체간의 관계도 구조는 위의 그림과 같습니다(포함관계 및 interface소유)


1. 각각의 ViewController가 unique한 Navigation Interface를 가지고 있는 것은 이전과 동일합니다.
> 예를 들어서 todayViewController의 경우 user가 오늘의 아티클을 tap하는 gesture가 존재합니다
이때 interface의 메서드의 경우 flow를 명확하게 알수있는 네이밍을 지양합니다(캡슐화에 위배)
단순히 유저가 어떤 action을 취했는지만을 나타내는 메서드명을 사용합니다
예를들어서 유저가 오늘의 아티클을 tap했을때의 결과가 명확한 todayArticleViewPresent같은 네이밍은 캡슐화를 위반합니다
```swift
protocol CurriculumNavigation: BarNavigation, ExpireNavigation {
    func articleListCellTapped(itemIndex: Int)
}
```

2. 각각의 ViewController는 이제 delegate으로 Coordinator 객체에게 요청을 보내는 것이 아닌 Adaptor 객체를 주입받습니다. 이 때 Adaptor의 타입은 1번에서 정의한 protocol 타입입니다.
```swift
final class CurriculumViewController: UIViewController, CurriculumControllerable  {
    var navigator: CurriculumNavigation
    private let manager: CurriculumManager
    ...
```

3. Coordinator protocol를 구현해줍니다. Coordinator가 담당하고 있는 ViewController에서 이루어지는 화면전환에 필요한 기능들을 가지고 있습니다. 이 때 네이밍은 flow에 알맞은 네이밍을 가집니다.
```swift
protocol CurriculumCoordinator: Coordinator {
    func showCurriculumViewController()
    func showCurriculumListViewController(itemIndex: Int)
    func showMypageViewController()
    func showBookmarkViewController()
    func showArticleDetailViewController(articleId: Int)
    func pop()
    func exitApplication()
}
```

4. Adaptor 객체를 구현해줍니다. 
Adaptor 객체는 ViewController에 주입되어야하기 때문에 1번에서 정의한 Navigation protocol을 채택하고 있고, 3번에서 정의한 Cooridnator protocol 타입의 `Coordinator`를 들고 있습니다.
이 때 Navigation protocol에서 정의된 메서드를 구현하는 구현부에서 Coordinator의 메서드를 이용해서 호출합니다.
```swift
typealias EntireCurriculumNavigation = CurriculumNavigation & CurriculumListByWeekNavigation


final class CurriculumAdaptor: EntireCurriculumNavigation {
    let coordinator: CurriculumCoordinator
    init(coordinator: CurriculumCoordinator) {
        self.coordinator = coordinator
    }
    
    func articleListCellTapped(itemIndex: Int) {
        self.coordinator.showCurriculumListViewController(itemIndex: itemIndex)
    }
    ...
```

5. Coordinator 객체를 구현해줍니다.  
이 때 Cooridnator 객체는 Adaptor에 주입되어야하기 때문에 3번에서 정의한 Coordinator protocol 타입을 채택하고 있습니다. 해당 protocol에서 정의된 메서드를 구현하는 구현부 내부에서 실제 화면전환 로직이 실행됩니다.
```swift
final class CurriculumCoordinatorImpl: CurriculumCoordinator {
    
    weak var parentCoordinator: Coordinator?

    let factory: CurriculumFactory

    var children: [Coordinator] = []

    var navigationController: UINavigationController

    init(navigationController: UINavigationController, factory: CurriculumFactory) {
        self.navigationController = navigationController
        self.factory = factory
    }

    func showArticleDetailViewController(articleId: Int) {  ...  }
    
    func showCurriculumListViewController(itemIndex: Int) {
        let curriculumListViewController = factory.makeCurriculumListViewController(coordinator: self)
        curriculumListViewController.setWeekIndexPath(week: itemIndex)
        navigationController.pushViewController(curriculumListViewController, animated: true)
    }
```

6. Coordinator에서 필요한 객체 생성은 `Factory`에게 맡깁니다. 
Factory는 Coordinator와 1:1 관계이며 각 Coordinator에서 필요한 객체 생성의 책임을 가지고 있습니다. Factory Pattern에 대해서는 해당 #150 에서 자세히 설명하고 있습니다.


변경된 점은 Factory에서 ViewController를 생성할 때 adaptor를 주입받습니다. 그리고 Adaptor를 생성할 때 Coordinator를 주입받기 때문에 Coordinator에서 Factory에게 ViewController를 만들어달라고 요청을 보낼 시에 인자로 자기 자신을 넘깁니다.
```swift
let curriculumListViewController = factory.makeCurriculumListViewController(coordinator: self)
```

이해를 돕기 위해 아래 사진을 첨부합니다(전체적인 coordinator의 flow에 관한 그림으로 보시면 좋을거같습니다)

<img width="552" alt="스크린샷 2023-10-19 오후 7 40 43" src="https://github.com/Team-LionHeart/LionHeart-iOS/assets/99013115/6e4955dc-8dac-4a28-9b9c-fcda3e00694e">




## Adaptor 도입 후 얻게 된 장점

## 장점 1.
문제점 1에서 언급했던 메소드의 네이밍마저 완전한 캡슐화와 관심사 분리가 되었습니다.
그로 인해 ViewController는 UI에 대한 action을, Coordinator는 화면전환 flow에만 집중된 메소드 네이밍을 가진 메소드만을 가질 수 있게 되었습니다.

## 장점 2.
Navigation interface와 Coordinator interface를 adaptor객체로 연결시켜주면서 두 interface사이의 depth를 두어,
화면전환 flow가 바뀐다 하더라도 그 변경의 영향이 더 core한 depth에 있는 `Coordinator`까지 미치지 않고 `Adaptor`의 변경만으로 `ViewController`의 화면전환 flow변경에 대응할수 있게 되었습니다. 

결과적으로 비교적 core한 depth에 있는 coordinator layer는 외부 변화가 있을 때 변경될 가능성이 낮아지게되고 이는 코드 전체의 안정성을 향상시켜줄 수있습니다.

## 장점 3.
또한 외부변화가 발생했을때(화면전환 flow변경) adaptor를 새로만들어서 주입시켜주거나 adaptor를 수정하면 되기때문에 OCP(*Open-Closed Principle*) 원칙에도 부합해, 보다 유연한 설계를 할 수 있게됩니다.

## 단점
의존성 주입과 책임들의 분리로 어마어마한 양의 보일러플레이트가 생기고 코드점핑이 급격하게 늘어납니다..
따라서 Coordinator(Adaptor) 패턴을 도입하기 위해서는 적용하기에 프로젝트가 괜찮은 규모인지, 팀원들이 모두 이를 이해할 수 있는지에 대한 검토가 선행되어야 할 것 같습니다.
![image](https://github.com/Team-LionHeart/LionHeart-iOS/assets/60292150/6e864081-0fc4-48f8-9b34-f491f6b994c4)

## 적용 PR들

### 민재(커리큘럼, 챌린지, 북마크)
- https://github.com/Team-LionHeart/LionHeart-iOS/pull/158

### 의성(투데이, 카테고리, 스플래시, 인증)
- https://github.com/Team-LionHeart/LionHeart-iOS/pull/154
- https://github.com/Team-LionHeart/LionHeart-iOS/pull/157

### 찬미(마이페이지, 아티클상세)
- https://github.com/Team-LionHeart/LionHeart-iOS/pull/160



## 📮 관련 이슈

- Resolved: #153 
