### PR TITLE
[REFACTOR] ChallengeVC를 DiffableDataSource와 MVVM(Combine)으로 리팩터링

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -243,6 +243,8 @@
 		C0B15E272AC104D50058D56B /* LHImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B15E262AC104D50058D56B /* LHImageButton.swift */; };
 		C0B15E292AC106CA0058D56B /* CurriculumListByCategoryTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B15E282AC106CA0058D56B /* CurriculumListByCategoryTableView.swift */; };
 		C0B15E2B2AC115F90058D56B /* LHView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B15E2A2AC115F90058D56B /* LHView.swift */; };
+		C0D47B602B08B640003B66E6 /* ChallengeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D47B5F2B08B640003B66E6 /* ChallengeViewModel.swift */; };
+		C0D47B622B08B6A3003B66E6 /* ChallengeViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D47B612B08B6A3003B66E6 /* ChallengeViewModelImpl.swift */; };
 		C0DF032B2A5A918F0037F740 /* TableViewCellRegisterDequeueProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DF032A2A5A918F0037F740 /* TableViewCellRegisterDequeueProtocol.swift */; };
 		C0DF032D2A5A91D90037F740 /* DataTypeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DF032C2A5A91D90037F740 /* DataTypeProtocol.swift */; };
 		C0DF032F2A5A92170037F740 /* NameSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DF032E2A5A92170037F740 /* NameSpace.swift */; };
@@ -568,6 +570,8 @@
 		C0B15E262AC104D50058D56B /* LHImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LHImageButton.swift; sourceTree = "<group>"; };
 		C0B15E282AC106CA0058D56B /* CurriculumListByCategoryTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumListByCategoryTableView.swift; sourceTree = "<group>"; };
 		C0B15E2A2AC115F90058D56B /* LHView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LHView.swift; sourceTree = "<group>"; };
+		C0D47B5F2B08B640003B66E6 /* ChallengeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeViewModel.swift; sourceTree = "<group>"; };
+		C0D47B612B08B6A3003B66E6 /* ChallengeViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeViewModelImpl.swift; sourceTree = "<group>"; };
 		C0DF032A2A5A918F0037F740 /* TableViewCellRegisterDequeueProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCellRegisterDequeueProtocol.swift; sourceTree = "<group>"; };
 		C0DF032C2A5A91D90037F740 /* DataTypeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTypeProtocol.swift; sourceTree = "<group>"; };
 		C0DF032E2A5A92170037F740 /* NameSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameSpace.swift; sourceTree = "<group>"; };
@@ -1688,6 +1692,8 @@
 			isa = PBXGroup;
 			children = (
 				C0DF03842A5AF7B70037F740 /* ChallengeViewController.swift */,
+				C0D47B5F2B08B640003B66E6 /* ChallengeViewModel.swift */,
+				C0D47B612B08B6A3003B66E6 /* ChallengeViewModelImpl.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -2018,6 +2024,7 @@
 				C0856B652ABFB8640026D9F8 /* TodayManagerImpl.swift in Sources */,
 				4AE19A1A2A65886100C1DB7E /* BookmarkReponse.swift in Sources */,
 				B5F323E92A6A8F0000047869 /* CurriculumWeekBackgroundDummy.swift in Sources */,
+				C0D47B622B08B6A3003B66E6 /* ChallengeViewModelImpl.swift in Sources */,
 				C0DF039F2A5CABC10037F740 /* GetPregnancyViewController.swift in Sources */,
 				F4DB30BC2A61691F00413EB9 /* CurriculumArticleByWeekRowZeroTableViewCell.swift in Sources */,
 				C009E9FC2ADBC4FD00112F18 /* ChallengeViewControllerable.swift in Sources */,
@@ -2138,6 +2145,7 @@
 				C0DF034D2A5A9B8D0037F740 /* (null) in Sources */,
 				C003CC3B2ADA4DA100AFFAAC /* DismissNavigation.swift in Sources */,
 				C003CC4B2ADA4F6300AFFAAC /* BookmarkNavigation.swift in Sources */,
+				C0D47B602B08B640003B66E6 /* ChallengeViewModel.swift in Sources */,
 				C09A33222A62D46300B40770 /* LHToast.swift in Sources */,
 				C003CC572ADA4FEB00AFFAAC /* UserState.swift in Sources */,
 				B59BFD352ADBBAE6005D2D81 /* CurriculumControllerable.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/Cells/ChallengeDayCheckCollectionViewCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/Cells/ChallengeDayCheckCollectionViewCollectionViewCell.swift
@@ -12,20 +12,13 @@ import SnapKit
 
 final class ChallengeDayCheckCollectionViewCollectionViewCell: UICollectionViewCell, CollectionViewCellRegisterDequeueProtocol {
     
+    enum ChallengeCellType { case read, yet }
+    
     private let countLabel = LHLabel(type: .body2M, color: .gray700, alignment: .center)
     private let lineView = LHUnderLine(lineColor: .gray900)
     
-    var inputString: String? {
-        didSet {
-            countLabel.text = inputString
-        }
-    }
-    
-    var whiteTextColor: UIColor?
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setUI()
         setHierarchy()
         setLayout()
     }
@@ -39,13 +32,22 @@ final class ChallengeDayCheckCollectionViewCollectionViewCell: UICollectionViewC
         countLabel.font = .pretendard(.body2M)
         countLabel.textColor = .designSystem(.gray700)
     }
+    
+    func configure(type: ChallengeCellType, input: ChallengeData, indexPath: IndexPath) {
+        switch type {
+        case .read:
+            countLabel.text = input.daddyAttendances[indexPath.item]
+            backgroundColor = .designSystem(.background)
+            countLabel.textColor = .designSystem(.white)
+        case .yet:
+            countLabel.text = "\(indexPath.section + indexPath.row + 1)"
+            backgroundColor = .designSystem(.gray1000)
+        }
+    }
 }
 
 private extension ChallengeDayCheckCollectionViewCollectionViewCell {
-    func setUI() {
-        backgroundColor = .designSystem(.gray1000)
-    }
-    
+
     func setHierarchy() {
         contentView.addSubviews(countLabel, lineView)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
@@ -72,8 +72,13 @@ final class ChallengeViewController: UIViewController, ChallengeViewControllerab
         let output = viewModel.transform(input: input)
         output.viewWillAppearSubject
             .receive(on: RunLoop.main)
-            .sink { [weak self] in
-                self?.configureData($0)
+            .sink { [weak self] result in
+                switch result {
+                case .success(let data):
+                    self?.configureData(data)
+                case .failure(let error):
+                    print(error.description)
+                }
             }
             .store(in: &cancelBag)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModel.swift
@@ -19,5 +19,5 @@ struct ChallengeViewModelInput {
 }
 
 struct ChallengeViewModelOutput {
-    let viewWillAppearSubject: AnyPublisher<ChallengeData, Never>
+    let viewWillAppearSubject: AnyPublisher<Result<ChallengeData, NetworkError>, Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  ChallengeViewModel.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/11/18.
+//
+
+import Foundation
+import Combine
+
+protocol ChallengeViewModelPresentable {}
+
+protocol ChallengeViewModel: ViewModel where Input == ChallengeViewModelInput, Output == ChallengeViewModelOutput {}
+
+struct ChallengeViewModelInput {
+    let navigationLeftButtonTapped: PassthroughSubject<Void, Never>
+    let navigationRightButtonTapped: PassthroughSubject<Void, Never>
+    let viewWillAppearSubject: PassthroughSubject<Void, Never>
+}
+
+struct ChallengeViewModelOutput {
+    let viewWillAppearSubject: AnyPublisher<ChallengeData, Never>
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModelImpl.swift
@@ -46,19 +46,16 @@ final class ChallengeViewModelImpl: ChallengeViewModel, ChallengeViewModelPresen
             .store(in: &cancelBag)
         
         let viewWillAppearSubject = input.viewWillAppearSubject
-            .flatMap { _ -> AnyPublisher<ChallengeData, Never> in
-                return Future<ChallengeData, NetworkError> { promise in
+            .flatMap { _ -> AnyPublisher<Result<ChallengeData, NetworkError>, Never> in
+                return Future<Result<ChallengeData, NetworkError>, Never> { promise in
                     Task {
                         do {
                             let inputData = try await self.manager.inquireChallengeInfo()
-                            promise(.success(inputData))
+                            promise(.success(.success(inputData)))
                         } catch {
-                            promise(.failure(error as! NetworkError))
+                            promise(.success(.failure(error as! NetworkError)))
                         }
                     }
-                }
-                .catch { error in
-                    Just(ChallengeData(babyDaddyName: error.description, howLongDay: 0, daddyLevel: "", daddyAttendances: []))
                 }
                 .eraseToAnyPublisher()
             }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewModelImpl.swift
@@ -1,0 +1,69 @@
+//
+//  ChallengeViewModelImpl.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/11/18.
+//
+
+import Foundation
+import Combine
+
+final class ChallengeViewModelImpl: ChallengeViewModel, ChallengeViewModelPresentable {
+    
+    private enum FlowType { case bookmarkButtonTapped, myPageButtonTapped }
+    
+    private let navigationSubject = PassthroughSubject<FlowType, Never>()
+    private var cancelBag = Set<AnyCancellable>()
+    
+    private var navigator: ChallengeNavigation
+    private var manager: ChallengeManager
+    
+    init(navigator: ChallengeNavigation, manager: ChallengeManager) {
+        self.navigator = navigator
+        self.manager = manager
+    }
+    
+    
+    func transform(input: ChallengeViewModelInput) -> ChallengeViewModelOutput {
+        navigationSubject
+            .receive(on: RunLoop.main)
+            .sink { [weak self] flow in
+                switch flow {
+                case .bookmarkButtonTapped:
+                    self?.navigator.navigationLeftButtonTapped()
+                case .myPageButtonTapped:
+                    self?.navigator.navigationRightButtonTapped()
+                }
+            }
+            .store(in: &cancelBag)
+        
+        input.navigationLeftButtonTapped
+            .sink { [weak self] in self?.navigationSubject.send(.bookmarkButtonTapped) }
+            .store(in: &cancelBag)
+        
+        input.navigationRightButtonTapped
+            .sink { [weak self] in self?.navigationSubject.send(.myPageButtonTapped) }
+            .store(in: &cancelBag)
+        
+        let viewWillAppearSubject = input.viewWillAppearSubject
+            .flatMap { _ -> AnyPublisher<ChallengeData, Never> in
+                return Future<ChallengeData, NetworkError> { promise in
+                    Task {
+                        do {
+                            let inputData = try await self.manager.inquireChallengeInfo()
+                            promise(.success(inputData))
+                        } catch {
+                            promise(.failure(error as! NetworkError))
+                        }
+                    }
+                }
+                .catch { error in
+                    Just(ChallengeData(babyDaddyName: error.description, howLongDay: 0, daddyLevel: "", daddyAttendances: []))
+                }
+                .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+        
+        return ChallengeViewModelOutput(viewWillAppearSubject: viewWillAppearSubject)
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ChallengeViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ChallengeViewControllerable.swift
@@ -7,6 +7,6 @@
 
 import UIKit
 
-protocol ChallengeViewControllerable where Self: UIViewController {
-    var navigator: ChallengeNavigation { get set }
-}
+//protocol ChallengeViewControllerable where Self: UIViewController {
+//    var navigator: ChallengeNavigation { get set }
+//}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ChallengeFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ChallengeFactoryImpl.swift
@@ -8,13 +8,24 @@
 import Foundation
 
 struct ChallengeFactoryImpl: ChallengeFactory {
+    
+    func makeChallengeViewModel(coordinator: ChallengeCoordinator) -> any ChallengeViewModel & ChallengeViewModelPresentable {
+        let adaptor = self.makeAdaptor(coordinator: coordinator)
+        let apiService = APIService()
+        let serviceImpl = ChallengeServiceImpl(apiService: apiService)
+        let managerImpl = ChallengeManagerImpl(challengeService: serviceImpl)
+        return ChallengeViewModelImpl(navigator: adaptor, manager: managerImpl)
+    }
+    
+    
+    
     func makeAdaptor(coordinator: ChallengeCoordinator) -> EntireChallengeNavigation {
         let adaptor = ChallengeAdaptor(coordinator: coordinator)
         return adaptor
     }
     
     func makeChallengeViewController(coordinator: ChallengeCoordinator) -> ChallengeViewControllerable {
-        let adaptor = self.makeAdaptor(coordinator: coordinator)
-        return ChallengeViewController(manager: ChallengeManagerImpl(challengeService: ChallengeServiceImpl(apiService: APIService())), navigator: adaptor)
+        let viewModel = makeChallengeViewModel(coordinator: coordinator)
+        return ChallengeViewController(viewModel: viewModel)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ChallengeFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ChallengeFactory.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol ChallengeFactory {
+    func makeChallengeViewModel(coordinator: ChallengeCoordinator) -> any ChallengeViewModel & ChallengeViewModelPresentable
     func makeAdaptor(coordinator: ChallengeCoordinator) -> EntireChallengeNavigation
     func makeChallengeViewController(coordinator: ChallengeCoordinator) -> ChallengeViewControllerable
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/Views/TodayArticleView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/Views/TodayArticleView.swift
@@ -34,7 +34,6 @@ final class TodayArticleView: UIView {
     
     override func draw(_ rect: CGRect) {
         super.draw(rect)
-        mainArticlImageView.setGradient(firstColor: .designSystem(.black)!.withAlphaComponent(0.2), secondColor: .designSystem(.gray1000)!, axis: .vertical)
         weekInfomationView.addSubview(weekInfomationLabel)
         mainArticlImageView.addSubviews(descriptionLabel, seperateLine, articleTitleLabel, weekInfomationView)
 


### PR DESCRIPTION
## [#169] REFACTOR : ChallengeVC를 DiffableDataSource와 MVVM(Combine)으로 리팩터링

## 🌱 작업한 내용
- ChallengeVC에서 기존 로직에서 불필요한 부분을 지우고 메서드분리를 진행
- ChallengeVC의 기존 datasource를 DiffableDataSource로 리팩터링
- ChallengeVC MVVM(Combine)으로 리팩터링

## 🌱 PR Point
### 1. 기존 ChallengeVC의 로직을 수정했습니다
기존에는 특정조건에따라서 cell의 UI컴포넌트에 직접접근해서 UI를 수정하는 방식이었습니다
코드가 길어지고 직관적이지 않다고 생각해서 아래와같은 코드로 수정헀습니다
```swift
let cell = ChallengeDayCheckCollectionViewCollectionViewCell.dequeueReusableCell(to: collectionView, indexPath: indexPath)
cell.configure(type: indexPath.item < input.daddyAttendances.count ? .read : .yet, input: input, indexPath: indexPath)
```
수정 후에는 cell의 type을 두가지로 나누고 type을 cell의 configure메서드에 전달해줍니다
```swift
func configure(type: ChallengeCellType, input: ChallengeData, indexPath: IndexPath) {
    switch type {
    case .read:
        countLabel.text = input.daddyAttendances[indexPath.item]
        backgroundColor = .designSystem(.background)
        countLabel.textColor = .designSystem(.white)
    case .yet:
        countLabel.text = "\(indexPath.section + indexPath.row + 1)"
        backgroundColor = .designSystem(.gray1000)
    }
}
```

### 2. Diffable DataSource로 리팩터링
- 기존의 DataSource방식으로도 문제는 없지만 WWDC에서 새로 소개된 Diffable DataSource가 Snapshot을 통한 기능적인 우위를 가지고 있으며 추후 확장성을 고려했을때 (현재 UI에서 cell의 변화는 없지만) UX적으로도 장점을 가지고 있으며 error에 유연하게 대응이 가능하다는 장점이 있으며 delegate대신 하기에 직관적인 UI를 그릴 수 있는 장점이 있다고 생각해 기존 datasource방식에 비해 상위호환이라고 생각했습니다
- 팀 내부에서 기존 datasource를 diffable datasource로의 리팩터링을 결정하게 되어 챌린지뷰에 적용했습니다

```swift
private var diffableDataSource: UICollectionViewDiffableDataSource<ChallengeSection, Int>!
```
Diffable DataSource를 정의해주고 메서드를 통해 dataSource를 만들어서 변수에 저장해줬습니다
```swift
func setDataSource(by input: ChallengeData) {
    diffableDataSource = .init(collectionView: challengeDayCheckCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
        let cell = ChallengeDayCheckCollectionViewCollectionViewCell.dequeueReusableCell(to: collectionView, indexPath: indexPath)
        cell.configure(type: indexPath.item < input.daddyAttendances.count ? .read : .yet, input: input, indexPath: indexPath)
        return cell
    })
}
```
그리고 원하는 데이터가 들어오면 snapshot을 통해 UI를 업데이트 해주는 방식입니다
```swift
func updateSections() {
    var snapshot = NSDiffableDataSourceSnapshot<ChallengeSection, Int>()
    snapshot.appendSections([.calendar])
    snapshot.appendItems([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20])
    self.diffableDataSource.apply(snapshot)
}
```

### 3. 기존의 MVC에서 Combine을 활용한 MVVM-C로의 리팩터링을 진행했습니다
- 해당 리팩터링을 진행하는 과정에서 함께 고민해봐야할 부분이 발생헀습니다
- 기존 Auth관련된 VC들을 MVVM으로 리팩터링하는 과정에서 flatmap을 통해 Future를 Never의 AnyPublisher로 받아왔었는데
- ChallengeVC와 같은 VC에서는 Future를 통해 특정 Data type을 stream에 흘려보내줘야합니다 이 과정에서 catch를 통해서 error가 발생헀을때 또다른 stream을 발생시켜야하는데 이때 AnyPublisher의 output type을 맞추기위해서는 Publisher가 error메세지가 아닌 Data type을 흘려보내주는 stream을 만들어야합니다
```swift
let viewWillAppearSubject = input.viewWillAppearSubject
    .flatMap { _ -> AnyPublisher<ChallengeData, Never> in
        return Future<ChallengeData, NetworkError> { promise in
            Task {
                do {
                    let inputData = try await self.manager.inquireChallengeInfo()
                    promise(.success(inputData))
                } catch {
                    promise(.failure(error as! NetworkError))
                }
            }
        }
        .catch { error in
            Just(ChallengeData(babyDaddyName: error.description, howLongDay: 0, daddyLevel: "", daddyAttendances: []))
        }
        .eraseToAnyPublisher()
    }
    .eraseToAnyPublisher()
```
여기서 발생할수있는 문제는 네트워크 통신에 실패했을때인데 이때 아래와같은 더미데이터밖에 보낼수가 없습니다
> ChallengeData(babyDaddyName: error.description, howLongDay: 0, daddyLevel: "", daddyAttendances: [])

@ffalswo2 @cchanmi 
이런 상황에서 error메세지를 보내는 stream의 필요성을 다시금 느끼게 되었습니다
그리고 이런상황일때 통신을 다시하는 방식으로 구현을 해야할것같다는 느낌이 들었습니다
결국 error가 발생했을때 어떤 로직을 통해 어떤 기능을 구현할건지에 대한 팀내 정의가 다시 필요할것같다는 생각이듦니다

## ⚠️11월18일 업데이트
고민을 좀 해봤는데 결국 VC가 에러자체를 처리하진 않더라도 어떤 에러가 발생했는지에 대한 정보는 알고있어야한다고 생각을 했고 Future의 성공 case에 resultType을 담아서 보내주면 VC에서 error의 description을 알수있게되는게 아닌가라는 생각을 하게되었습니다

최종적으로 Future자체가 실패Case가 존재하지 않고 error가 발생하거나 성공했을때 Future자체에서는 성공 flag를 보내고 vc에서 해당 성공 resulttype을 받아서 error가발생했다면 어떤 error가 발생했는지를 받는 방식으로 코드를 수정했습니다
```swift
let viewWillAppearSubject = input.viewWillAppearSubject
    .flatMap { _ -> AnyPublisher<Result<ChallengeData, NetworkError>, Never> in
        return Future<Result<ChallengeData, NetworkError>, Never> { promise in
            Task {
                do {
                    let inputData = try await self.manager.inquireChallengeInfo()
                    promise(.success(.success(inputData)))
                } catch {
                    promise(.success(.failure(error as! NetworkError)))
                }
            }
        }
        .eraseToAnyPublisher()
    }
    .eraseToAnyPublisher()
```
최대한 catch를 사용해서 리팩터링을 진행해보고 싶었는데 error가 발생헀을때 새로운 publisher를 만들어서 던진다는 메커니즘이 좀 쉽게 사용하기 어려운것같습니다, 그리고 이방식이 좋은방식인지는 잘 모르겠습니다 만약에 이방식이 의미가 있으려면 단순히 error를 던지는게 아니라 그 error를 vm에서 받아서 handling하는 코드나 로직이 추가로 필요할것같습니다.

### 단순제안
@ffalswo2 @cchanmi 
그런데 에러가 발생했을때 challengevc의 UI가 없는 상태로 놔둘수는 없으니 catch를 통해서 빈 구조체라도 보내서 UI가 최소한의 구현은 되어있게 하기위해서 catch를 통해서 default 구조체를 보내줘 최소한의 UI는 구현이 되어있게 하고 VM에서 error를 받아서 뭔가 처리를 하는 방식이 UI/UX적으로도 조금더 맞지않나라는 생각이 드네요

result를 사용하게되면 error를 받으면 challengeVC의 UI가 아얘 없는 상태로 유저에게 보여지게될겁니다...그것보다는 catch를 사용해서 default구조체라도 넘겨줘서 최소한의 UI를 그려주고 error를 VM내부의 handle 메서드에 넣어주는건 어떨까요?

> 근데 이런경우는 네트워킹 통신을 실패한 경우니까 `retry`를 이용해서 성공할때까지 몇번 계속 실행하도록 해봐야하지 않을까 싶네요


## 📮 관련 이슈

- Resolved: #168 
