### PR TITLE
[REFACTOR] 아티클뷰 DiffableDataSource로 변경 및 MVVM(Combine)-C로 리팩토링 (#167)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		B520EA6C2A670C010027356E /* progressbar_2m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA632A670C010027356E /* progressbar_2m.json */; };
 		B520EA6D2A670C010027356E /* progressbar_3m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA642A670C010027356E /* progressbar_3m.json */; };
 		B520EA6E2A670C010027356E /* progressbar_5m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA652A670C010027356E /* progressbar_5m.json */; };
+		B5234F9B2B0A61D700D6EE58 /* ArticleDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */; };
+		B5234F9D2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */; };
 		B52C6BB42AF8AE1D008E3B99 /* Combine+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */; };
 		B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8312A5525C600F0DB19 /* AppDelegate.swift */; };
 		B532E8342A5525C600F0DB19 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8332A5525C600F0DB19 /* SceneDelegate.swift */; };
@@ -380,6 +382,8 @@
 		B520EA632A670C010027356E /* progressbar_2m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_2m.json; sourceTree = "<group>"; };
 		B520EA642A670C010027356E /* progressbar_3m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_3m.json; sourceTree = "<group>"; };
 		B520EA652A670C010027356E /* progressbar_5m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_5m.json; sourceTree = "<group>"; };
+		B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailViewModel.swift; sourceTree = "<group>"; };
+		B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailViewModelImpl.swift; sourceTree = "<group>"; };
 		B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+.swift"; sourceTree = "<group>"; };
 		B532E82E2A5525C600F0DB19 /* LionHeart-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "LionHeart-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B532E8312A5525C600F0DB19 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -772,6 +776,15 @@
 			path = Auth;
 			sourceTree = "<group>";
 		};
+		B5234F992B0A61CE00D6EE58 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */,
+				B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		B532E8252A5525C600F0DB19 = {
 			isa = PBXGroup;
 			children = (
@@ -1082,6 +1095,7 @@
 		B598920B2A56B3A300CE1FEB /* ArticleDetail */ = {
 			isa = PBXGroup;
 			children = (
+				B5234F992B0A61CE00D6EE58 /* ViewModel */,
 				B5C6A2C92A5EF5210021BE5E /* Model */,
 				B598922B2A56B6C100CE1FEB /* Cells */,
 				B598922A2A56B6BE00CE1FEB /* Views */,
@@ -2079,6 +2093,7 @@
 				C0B15E292AC106CA0058D56B /* CurriculumListByCategoryTableView.swift in Sources */,
 				C003CC2F2AD9189F00AFFAAC /* MypageCoordinator.swift in Sources */,
 				C003CC5E2ADA508A00AFFAAC /* LoginManager.swift in Sources */,
+				B5234F9B2B0A61D700D6EE58 /* ArticleDetailViewModel.swift in Sources */,
 				C065F00B2ADBD2800094912C /* LoginViewControllerable.swift in Sources */,
 				C06E38232A65353F00B00600 /* LoginType.swift in Sources */,
 				C0856B6B2ABFBC9D0026D9F8 /* ArticleDetailManagerImpl.swift in Sources */,
@@ -2087,6 +2102,7 @@
 				C003CC272AD9185A00AFFAAC /* ArticleCategoryCoordinatorImpl.swift in Sources */,
 				C0DF03962A5B8FB10037F740 /* Palette.swift in Sources */,
 				C003CC682ADA51A700AFFAAC /* ArticleListByCategoryManager.swift in Sources */,
+				B5234F9D2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift in Sources */,
 				C003CC6A2ADA51C000AFFAAC /* MyPageManager.swift in Sources */,
 				4A3D72872A5D405C00A36189 /* BookmarkListCollectionViewCell.swift in Sources */,
 				C003CC622ADA50C000AFFAAC /* TodayManager.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Cells/ThumnailTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Cells/ThumnailTableViewCell.swift
@@ -15,9 +15,9 @@ final class ThumnailTableViewCell: UITableViewCell, TableViewCellRegisterDequeue
     private let gradientImageView = LHImageView(in: ImageLiterals.Curriculum.gradient, contentMode: .scaleAspectFill)
     private let thumbnailImageView = LHImageView(contentMode: .scaleAspectFill)
     private let imageCaptionLabel = LHLabel(type: .body4, color: .gray500)
-    private lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkBig, select: ImageLiterals.BookMark.activeBookmarkBig)
+    lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkBig, select: ImageLiterals.BookMark.activeBookmarkBig)
 
-    var bookmarkButtonDidTap: ((Bool) -> Void)?
+//    var bookmarkButtonDidTap: ((Bool) -> Void)?
     var inputData: ArticleBlockData? {
         didSet {
             configureCell(inputData)
@@ -95,11 +95,11 @@ private extension ThumnailTableViewCell {
     }
     
     func setAddTarget() {
-        bookMarkButton.addButtonAction { [weak self] _ in
-            guard let self else { return }
-            self.isSelected.toggle()
-            self.bookmarkButtonDidTap?(self.isSelected)
-        }
+//        bookMarkButton.addButtonAction { [weak self] _ in
+//            guard let self else { return }
+//            self.isSelected.toggle()
+//            self.bookmarkButtonDidTap?(self.isSelected)
+//        }
     }
 }
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Model/ArticleBlockType.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Model/ArticleBlockType.swift
@@ -7,15 +7,20 @@
 
 import UIKit
 
+// MARK: - Section
+enum ArticleDetailSection {
+    case articleMain
+}
+
 // MARK: - AppData
 
-struct ArticleBlockData: AppData {
+struct ArticleBlockData: Hashable, AppData {
     let content: String
     let caption: String?
 }
 
 @frozen
-enum BlockTypeAppData {
+enum BlockTypeAppData: Hashable {
     case thumbnail(isMarked: Bool, model: ArticleBlockData)
     case articleTitle(model: ArticleBlockData)
     case editorNote(model: ArticleBlockData)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -7,14 +7,27 @@
 //
 
 import UIKit
+import Combine
 
 import SnapKit
 
 final class ArticleDetailViewController: UIViewController, ArticleControllerable {
     
-    // MARK: - UI Components
-    var adaptor: ArticleDetailModalNavigation
-    private let manager: ArticleDetailManager
+    
+    private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
+    
+    private let closeButtonTapped = PassthroughSubject<Void, Never>()
+    
+    private let bookmarkButtonTapped = PassthroughSubject<Void, Never>()
+    
+    private let viewModel: any ArticleDetailViewModel
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    private var datasource: UITableViewDiffableDataSource<ArticleDetailSection, BlockTypeAppData>!
+    
+//    var adaptor: ArticleDetailModalNavigation
+//    private let manager: ArticleDetailManager
     
     private lazy var navigationBar = LHNavigationBarView(type: .articleMain, viewController: self)
     
@@ -26,27 +39,26 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
 
     // MARK: - Properties
 
-    private var isBookMarked: Bool? {
-        didSet {
-            guard let isBookMarked else { return }
-            LHToast.show(message: isBookMarked ? "북마크가 추가되었습니다" : "북마크가 해제되었습니다")
-        }
-    }
+//    private var isBookMarked: Bool? {
+//        didSet {
+//            guard let isBookMarked else { return }
+//            LHToast.show(message: isBookMarked ? "북마크가 추가되었습니다" : "북마크가 해제되었습니다")
+//        }
+//    }
+//
+//    private var articleDatas: [BlockTypeAppData]? {
+//        didSet {
+//            self.articleTableView.reloadData()
+//            hideLoading()
+//        }
+//    }
 
-    private var articleDatas: [BlockTypeAppData]? {
-        didSet {
-            self.articleTableView.reloadData()
-            hideLoading()
-        }
-    }
-
-    private var articleId: Int?
+//    private var articleId: Int?
 
     private var contentOffsetY: CGFloat = 0
     
-    init(manager: ArticleDetailManager, adaptor: ArticleDetailModalNavigation) {
-        self.manager = manager
-        self.adaptor = adaptor
+    init(viewModel: some ArticleDetailViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -60,54 +72,167 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
         setUI()
         setHierarchy()
         setLayout()
-        setAddTarget()
         setTableView()
         setNavigationBar()
         setTabbar()
+        bindInput()
+        bind()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        viewWillAppearSubject.send(())
         showLoading()
-        getArticleDetail()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.tabBarController?.tabBar.isHidden = false
     }
+    
+    private func bindInput() {
+        scrollToTopButton.tapPublisher
+            .sink { [weak self] _ in
+                guard let self else { return }
+                let indexPath = IndexPath(row: 0, section: 0)
+                self.articleTableView.scrollToRow(at: indexPath, at: .top, animated: true)
+                self.scrollToTopButton.isHidden = true
+            }
+            .store(in: &cancelBag)
+        
+        navigationBar.leftBarItem.tapPublisher
+            .sink { _ in
+                self.closeButtonTapped.send(())
+            }
+            .store(in: &cancelBag)
+    }
+    
+    private func bind() {
+        let input = ArticleDetailViewModelInput(viewWillAppear: viewWillAppearSubject,
+                                                closeButtonTapped: closeButtonTapped,
+                                                bookmarkButtonTapped: bookmarkButtonTapped)
+        let output = viewModel.transform(input: input)
+        output.articleDetail
+            .sink { [weak self] result in
+                guard let self else { return }
+                self.hideLoading()
+                
+                switch result {
+                case .success(let article):
+                    //TODO: - DataSource apply snapshot
+                    self.setDatasource(blockTypes: article.blockTypes,
+                                       isBookMarked: article.isMarked)
+                    self.applySnapshot(article.blockTypes)
+                case .failure(let error):
+                    print(error.description)
+                }
+            }
+            .store(in: &cancelBag)
+    }
 }
-
-// MARK: - Network
 
 extension ArticleDetailViewController {
-    private func getArticleDetail() {
-        Task {
-            do {
-                guard let articleId else { return }
-                self.articleDatas = try await manager.getArticleDetail(articleId: articleId)
-            } catch {
-                guard let error = error as? NetworkError else { return }
-                handleError(error)
+    private func setDatasource(blockTypes: [BlockTypeAppData], isBookMarked: Bool) {
+        self.datasource = UITableViewDiffableDataSource(tableView: self.articleTableView,
+                                                        cellProvider: { tableView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .thumbnail(let isMarked, let thumbnailModel):
+                let cell = ThumnailTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = thumbnailModel
+                cell.selectionStyle = .none
+                
+                cell.bookMarkButton.tapPublisher
+                    .sink { [weak self] _ in
+                        self?.bookmarkButtonTapped.send(())
+                    }
+                    .store(in: &self.cancelBag)
+
+                if isBookMarked {
+                    cell.isMarked = isBookMarked
+                } else {
+                    cell.isMarked = isMarked
+                }
+                cell.setThumbnailImageView()
+                return cell
+            case .articleTitle(let titleModel):
+                let cell = TitleTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = titleModel
+                cell.selectionStyle = .none
+                return cell
+            case .editorNote(let editorModel):
+                let cell = EditorTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = editorModel
+                cell.selectionStyle = .none
+                return cell
+            case .chapterTitle(let chapterTitleModel):
+                let cell = ChapterTitleTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = chapterTitleModel
+                cell.selectionStyle = .none
+                return cell
+            case .body(let bodyModel):
+                let cell = BodyTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = bodyModel
+                cell.selectionStyle = .none
+                return cell
+            case .generalTitle(let generalTitleModel):
+                let cell = GeneralTitleTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = generalTitleModel
+                cell.selectionStyle = .none
+                return cell
+            case .image(let imageModel):
+                let cell = ThumnailTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = imageModel
+                cell.setImageTypeCell()
+                cell.selectionStyle = .none
+                return cell
+            case .endNote:
+                let cell = CopyRightTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.selectionStyle = .none
+                return cell
+            case .none:
+                return UITableViewCell()
             }
-        }
+        })
     }
-
-    private func articleBookMark(articleId: Int, isSelected: Bool) {
-        Task {
-            do {
-                let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
-                try await manager.postBookmark(model: bookmarkRequest)
-
-                isBookMarked = isSelected
-            } catch {
-                guard let error = error as? NetworkError else { return }
-                self.handleError(error)
-            }
-        }
-
+    
+    func applySnapshot(_ blocks: [BlockTypeAppData]) {
+        var snapshot = NSDiffableDataSourceSnapshot<ArticleDetailSection, BlockTypeAppData>()
+        snapshot.appendSections([.articleMain])
+        snapshot.appendItems(blocks)
+        self.datasource.apply(snapshot, animatingDifferences: false)
     }
 }
+
+//// MARK: - Network
+//
+//extension ArticleDetailViewController {
+//    private func getArticleDetail() {
+//        Task {
+//            do {
+//                guard let articleId else { return }
+//                self.articleDatas = try await manager.getArticleDetail(articleId: articleId)
+//            } catch {
+//                guard let error = error as? NetworkError else { return }
+//                handleError(error)
+//            }
+//        }
+//    }
+//
+//    private func articleBookMark(articleId: Int, isSelected: Bool) {
+//        Task {
+//            do {
+//                let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
+//                try await manager.postBookmark(model: bookmarkRequest)
+//
+//                isBookMarked = isSelected
+//            } catch {
+//                guard let error = error as? NetworkError else { return }
+//                self.handleError(error)
+//            }
+//        }
+//
+//    }
+//}
 
 //extension ArticleDetailViewController: ViewControllerServiceable {
 //    func handleError(_ error: NetworkError) {
@@ -163,7 +288,7 @@ private extension ArticleDetailViewController {
 
     func setTableView() {
         articleTableView.delegate = self
-        articleTableView.dataSource = self
+//        articleTableView.dataSource = self
     }
 
     func setNavigationBar() {
@@ -172,18 +297,6 @@ private extension ArticleDetailViewController {
     
     func setTabbar() {
         self.tabBarController?.tabBar.isHidden = true
-    }
-
-    func setAddTarget() {
-        navigationBar.backButtonAction {
-            self.adaptor.closeButtonTapped()
-        }
-        
-        scrollToTopButton.addButtonAction { _ in
-            let indexPath = IndexPath(row: 0, section: 0)
-            self.articleTableView.scrollToRow(at: indexPath, at: .top, animated: true)
-            self.scrollToTopButton.isHidden = true
-        }
     }
 }
 
@@ -205,79 +318,85 @@ extension ArticleDetailViewController: UITableViewDelegate {
 
 }
 
-extension ArticleDetailViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return articleDatas?.count ?? 0
-    }
+//extension ArticleDetailViewController: UITableViewDataSource {
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return articleDatas?.count ?? 0
+//    }
+//
+//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//        guard let articleDatas else { return UITableViewCell() }
+//
+//        switch articleDatas[indexPath.row] {
+//        case .thumbnail(let isMarked, let thumbnailModel):
+//            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = thumbnailModel
+//            cell.selectionStyle = .none
+//            cell.bookMarkButton.tapPublisher
+//                .sink { [weak self] _ in
+//                    self?.bookmarkButtonTapped.send(())
+//                }
+//                .store(in: &cancelBag)
+//                
+////            cell.bookmarkButtonDidTap = { isSelected in
+////                guard let articleId = self.articleId else { return }
+////
+////                self.articleBookMark(articleId: articleId, isSelected: isSelected)
+////            }
+//
+//            if let isBookMarked {
+//                cell.isMarked = isBookMarked
+//            } else {
+//                cell.isMarked = isMarked
+//            }
+//            cell.setThumbnailImageView()
+//            return cell
+//        case .articleTitle(let titleModel):
+//            let cell = TitleTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = titleModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .editorNote(let editorModel):
+//            let cell = EditorTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = editorModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .chapterTitle(let chapterTitleModel):
+//            let cell = ChapterTitleTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = chapterTitleModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .body(let bodyModel):
+//            let cell = BodyTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = bodyModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .generalTitle(let generalTitleModel):
+//            let cell = GeneralTitleTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = generalTitleModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .image(let imageModel):
+//            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = imageModel
+//            cell.setImageTypeCell()
+//            cell.selectionStyle = .none
+//            return cell
+//        case .endNote:
+//            let cell = CopyRightTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.selectionStyle = .none
+//            return cell
+//        case .none:
+//            return UITableViewCell()
+//        }
+//    }
+//
+//}
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let articleDatas else { return UITableViewCell() }
 
-        switch articleDatas[indexPath.row] {
-        case .thumbnail(let isMarked, let thumbnailModel):
-            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = thumbnailModel
-            cell.selectionStyle = .none
-            cell.bookmarkButtonDidTap = { isSelected in
-                guard let articleId = self.articleId else { return }
-
-                self.articleBookMark(articleId: articleId, isSelected: isSelected)
-            }
-
-            if let isBookMarked {
-                cell.isMarked = isBookMarked
-            } else {
-                cell.isMarked = isMarked
-            }
-            cell.setThumbnailImageView()
-            return cell
-        case .articleTitle(let titleModel):
-            let cell = TitleTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = titleModel
-            cell.selectionStyle = .none
-            return cell
-        case .editorNote(let editorModel):
-            let cell = EditorTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = editorModel
-            cell.selectionStyle = .none
-            return cell
-        case .chapterTitle(let chapterTitleModel):
-            let cell = ChapterTitleTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = chapterTitleModel
-            cell.selectionStyle = .none
-            return cell
-        case .body(let bodyModel):
-            let cell = BodyTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = bodyModel
-            cell.selectionStyle = .none
-            return cell
-        case .generalTitle(let generalTitleModel):
-            let cell = GeneralTitleTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = generalTitleModel
-            cell.selectionStyle = .none
-            return cell
-        case .image(let imageModel):
-            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = imageModel
-            cell.setImageTypeCell()
-            cell.selectionStyle = .none
-            return cell
-        case .endNote:
-            let cell = CopyRightTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.selectionStyle = .none
-            return cell
-        case .none:
-            return UITableViewCell()
-        }
-    }
-
-}
-
-
-extension ArticleDetailViewController {
-    /// Article ID를 해당 메서드로 넘긴 후에 해당 VC를 present해주세요
-    /// - Parameter id: articleId
-    func setArticleId(id: Int?) {
-        self.articleId = id
-    }
-}
+//extension ArticleDetailViewController {
+//    /// Article ID를 해당 메서드로 넘긴 후에 해당 VC를 present해주세요
+//    /// - Parameter id: articleId
+//    func setArticleId(id: Int?) {
+//        self.articleId = id
+//    }
+//}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -128,6 +128,12 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
                 }
             }
             .store(in: &cancelBag)
+        
+        output.bookmarkCompleted
+            .sink { str in
+                print(str)
+            }
+            .store(in: &cancelBag)
     }
 }
 
@@ -143,6 +149,7 @@ extension ArticleDetailViewController {
                 
                 cell.bookMarkButton.tapPublisher
                     .sink { [weak self] _ in
+                        cell.isMarked?.toggle()
                         self?.bookmarkButtonTapped.send(())
                     }
                     .store(in: &self.cancelBag)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  ArticleDetailViewModel.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+protocol ArticleDetailViewModelPresentable {
+    func setArticleId(id: Int)
+}
+
+protocol ArticleDetailViewModel: ViewModel where Input == ArticleDetailViewModelInput, Output == ArticleDetailViewModelOutput {}
+
+struct ArticleDetailViewModelInput {
+    let viewWillAppear: PassthroughSubject<Void, Never>
+    let closeButtonTapped: PassthroughSubject<Void, Never>
+    let bookmarkButtonTapped: PassthroughSubject<Void, Never>
+}
+
+struct ArticleDetailViewModelOutput {
+    let articleDetail: AnyPublisher<Result<Article, NetworkError>, Never>
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
@@ -18,9 +18,11 @@ struct ArticleDetailViewModelInput {
     let viewWillAppear: PassthroughSubject<Void, Never>
     let closeButtonTapped: PassthroughSubject<Void, Never>
     let bookmarkButtonTapped: PassthroughSubject<Void, Never>
+    let scrollToTopButtonTapped: PassthroughSubject<Void, Never>
 }
 
 struct ArticleDetailViewModelOutput {
-    let articleDetail: AnyPublisher<Result<Article, NetworkError>, Never>
+    let articleDetail: AnyPublisher<Article, Never>
     let bookmarkCompleted: AnyPublisher<String, Never>
+    let scrollToTopButtonTapped: AnyPublisher<Void, Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
@@ -22,4 +22,5 @@ struct ArticleDetailViewModelInput {
 
 struct ArticleDetailViewModelOutput {
     let articleDetail: AnyPublisher<Result<Article, NetworkError>, Never>
+    let bookmarkCompleted: AnyPublisher<String, Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModelImpl.swift
@@ -1,0 +1,144 @@
+//
+//  ArticleDetailViewModelImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+struct Article {
+    let blockTypes: [BlockTypeAppData]
+    let isMarked: Bool
+}
+
+final class ArticleDetailViewModelImpl: ArticleDetailViewModel, ArticleDetailViewModelPresentable {
+    
+    private enum FlowType {
+        case closeButtonTapped
+        case expired
+    }
+    
+    private var adaptor: ArticleDetailModalNavigation
+    private let manager: ArticleDetailManager
+    
+    private let navigationSubject = PassthroughSubject<FlowType, Never>()
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    private var isBookMarked: Bool?
+//    {
+//        didSet {
+//            guard let isBookMarked else { return }
+//            LHToast.show(message: isBookMarked ? "북마크가 추가되었습니다" : "북마크가 해제되었습니다")
+//        }
+//    }
+
+    private var articleDatas: [BlockTypeAppData]?
+//    {
+//        didSet {
+//            self.articleTableView.reloadData()
+//            hideLoading()
+//        }
+//    }
+    
+    private var articleId: Int?
+    
+    init(adaptor: ArticleDetailModalNavigation, manager: ArticleDetailManager) {
+        self.adaptor = adaptor
+        self.manager = manager
+    }
+    
+    func transform(input: ArticleDetailViewModelInput) -> ArticleDetailViewModelOutput {
+        
+        navigationSubject
+            .receive(on: RunLoop.main)
+            .sink { [weak self] flow in
+                guard let self else { return }
+                switch flow {
+                case .closeButtonTapped:
+                    self.adaptor.closeButtonTapped()
+                case .expired:
+                    self.adaptor.checkTokenIsExpired()
+                }
+            }
+            .store(in: &cancelBag)
+        
+        input.closeButtonTapped
+            .sink { [weak self] _ in
+                self?.navigationSubject.send(.closeButtonTapped)
+            }
+            .store(in: &cancelBag)
+        
+        
+        let articleBlockTypes = input.viewWillAppear
+            .flatMap { _ -> AnyPublisher<Result<Article, NetworkError>, Never> in
+                return Future<Result<Article, NetworkError>, NetworkError> { promise in
+                    Task {
+                        do {
+                            guard let articleId = self.articleId else { return }
+                            let articleBlocks = try await self.getArticleDetail(articleId: articleId)
+                            let thumbnail = articleBlocks[0]
+                            if case .thumbnail(let isMarked, _) = thumbnail {
+                                self.isBookMarked = isMarked
+                                promise(.success(.success(Article(blockTypes: articleBlocks, isMarked: isMarked))))
+                            }
+                        } catch {
+                            guard let error = error as? NetworkError else { return }
+                            self.handleError(error)
+                        }
+                    }
+                }
+                .catch { error in
+                    return Just(.failure(error))
+                }
+                .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+        
+        
+        return Output(articleDetail: articleBlockTypes)
+    }
+    
+}
+
+// MARK: - Network
+
+extension ArticleDetailViewModelImpl {
+    private func getArticleDetail(articleId: Int) async throws -> [BlockTypeAppData] {
+        return try await manager.getArticleDetail(articleId: articleId)
+    }
+
+    private func articleBookMark(articleId: Int, isSelected: Bool) {
+        Task {
+            do {
+                let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
+                try await manager.postBookmark(model: bookmarkRequest)
+
+                isBookMarked = isSelected
+            } catch {
+                guard let error = error as? NetworkError else { return }
+                self.handleError(error)
+            }
+        }
+
+    }
+}
+
+extension ArticleDetailViewModelImpl {
+    func handleError(_ error: NetworkError) {
+        if case .unAuthorizedError = error {
+            self.navigationSubject.send(.expired)
+        }
+    }
+}
+
+
+extension ArticleDetailViewModelImpl {
+    /// Article ID를 해당 메서드로 넘긴 후에 해당 VC를 present해주세요
+    /// - Parameter id: articleId
+    func setArticleId(id: Int) {
+        self.articleId = id
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
@@ -9,6 +9,6 @@ import UIKit
 
 
 protocol ArticleControllerable where Self: UIViewController {
-    func setArticleId(id: Int?)
-    var adaptor: ArticleDetailModalNavigation { get set }
+//    func setArticleId(id: Int?)
+//    var adaptor: ArticleDetailModalNavigation { get set }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
@@ -8,7 +8,4 @@
 import UIKit
 
 
-protocol ArticleControllerable where Self: UIViewController {
-//    func setArticleId(id: Int?)
-//    var adaptor: ArticleDetailModalNavigation { get set }
-}
+protocol ArticleControllerable where Self: UIViewController {}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCoordinatorImpl.swift
@@ -28,8 +28,8 @@ final class ArticleCoordinatorImpl: ArticleCoordinator {
     }
     
     func showArticleDetailViewController() {
-        let articleDetailViewController = factory.makeArticleDetailViewController(coordinator: self)
-        articleDetailViewController.setArticleId(id: articleId)
+        let articleDetailViewController = factory.makeArticleDetailViewController(coordinator: self, articleId: articleId)
+//        articleDetailViewController.setArticleId(id: articleId)
         articleDetailViewController.isModalInPresentation = true
         articleDetailViewController.modalPresentationStyle = .fullScreen
         navigationController.present(articleDetailViewController, animated: true)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleFactoryImpl.swift
@@ -8,19 +8,26 @@
 import Foundation
 
 struct ArticleFactoryImpl: ArticleFactory {
-    func makeAdaptor(coordinator: ArticleCoordinator) -> EntireArticleAdaptor {
-        let adaptor = ArticleAdaptor(coordinator: coordinator)
-        return adaptor
-    }
     
-    func makeArticleDetailViewController(coordinator: ArticleCoordinator) -> ArticleControllerable {
+    func makeArticleViewModel(coordinator: ArticleCoordinator) -> any ArticleDetailViewModel & ArticleDetailViewModelPresentable {
         let adaptor = self.makeAdaptor(coordinator: coordinator)
         let apiService = APIService()
         let bookmarkService = BookmarkServiceImpl(apiService: apiService)
         let articleService = ArticleServiceImpl(apiService: apiService)
         let manager = ArticleDetailManagerImpl(articleService: articleService,
                                                             bookmarkService: bookmarkService)
-        let articleDetailViewController = ArticleDetailViewController(manager: manager, adaptor: adaptor)
+        return ArticleDetailViewModelImpl(adaptor: adaptor, manager: manager)
+    }
+    
+    func makeAdaptor(coordinator: ArticleCoordinator) -> EntireArticleAdaptor {
+        let adaptor = ArticleAdaptor(coordinator: coordinator)
+        return adaptor
+    }
+    
+    func makeArticleDetailViewController(coordinator: ArticleCoordinator, articleId: Int) -> ArticleControllerable {
+        let viewModel = self.makeArticleViewModel(coordinator: coordinator)
+        viewModel.setArticleId(id: articleId)
+        let articleDetailViewController = ArticleDetailViewController(viewModel: viewModel)
         return articleDetailViewController
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleFactory.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol ArticleFactory {
+    func makeArticleViewModel(coordinator: ArticleCoordinator) -> any ArticleDetailViewModel & ArticleDetailViewModelPresentable
     func makeAdaptor(coordinator: ArticleCoordinator) -> EntireArticleAdaptor
-    func makeArticleDetailViewController(coordinator: ArticleCoordinator) -> ArticleControllerable
+    func makeArticleDetailViewController(coordinator: ArticleCoordinator, articleId: Int) -> ArticleControllerable
 }


### PR DESCRIPTION
## 🌱 작업한 내용

- ArticleDetail 기존 DataSource를 DiffableDataSource로 변경 
- ArticleDetail MVC-C -> MVVM(Combine)-C로 리팩토링

## 🌱 PR Point
### 기존 DataSource에서 DiffableDataSource로 변경
리팩토링 과정에서 팀원들과 이야기를 하던중, DiffableDataSource가 기존의 DataSource보다 성능상 이점이 있다는 것과, 변경되는 데이터에 대해 기본으로 제공되는 깔끔한 애니메이션을 통해서 더 나은 경험을 제공할 수 있는 DiffableDataSource로 변경하기로 결정되었습니다.

### 기존 `MVC-C`를 `MVVM-C`로 리팩토링
MVC-C에서 ViewController에 남아있는 마지막 데이터 로직을 분리하기 위한 ViewModel을 가지는 MVVM아키텍처로 변경했습니다. 이 때 ViewModel에 있는 데이터와 UI를 데이터 바인딩을 하기 위해서 Combine을 활용합니다.

그 중에서도 Input-Output구조를 채택함으로써 팀원들간에 통일된 구조를 가질 수 있었습니다. 또한, Input Output구조체를 통해서 ViewController와 ViewModel간에 주고받는 데이터를 한눈에 쉽게 알 수 있다는 장점이 있습니다.

```swift
struct ArticleDetailViewModelInput {
    let viewWillAppear: PassthroughSubject<Void, Never>
    let closeButtonTapped: PassthroughSubject<Void, Never>
    let bookmarkButtonTapped: PassthroughSubject<Void, Never>
    let scrollToTopButtonTapped: PassthroughSubject<Void, Never>
}

struct ArticleDetailViewModelOutput {
    let articleDetail: AnyPublisher<Article, Never>
    let bookmarkCompleted: AnyPublisher<String, Never>
    let scrollToTopButtonTapped: AnyPublisher<Void, Never>
}
```

전체적인 흐름은 ViewController에서 user action을 `Input`구조체로 만들고, ViewModel의 `transform(input:)` 메서드에 인자로 넘김으로써 ViewModel에서 필요한 비즈니스 로직들을 거치게 됩니다.
```swift
let input = ArticleDetailViewModelInput(viewWillAppear: viewWillAppearSubject,
                                                closeButtonTapped: closeButtonTapped,
                                                bookmarkButtonTapped: bookmarkButtonTapped,
                                                scrollToTopButtonTapped: scrollToTopButtonTapped)
let output = viewModel.transform(input: input)
```

ViewModel의 transform에서는 Operator를 통해서 비즈니스 로직을 거친 후에  Output구조체에 stream을 담아 return합니다.
```swift
let articleBlockTypes = input.viewWillAppear
            .flatMap { _ -> AnyPublisher<Article, Never> in
                ...
                }
                .eraseToAnyPublisher()
            }
            .eraseToAnyPublisher()

return Output(articleDetail: articleBlockTypes, ...)
```

ViewController에서 transform을 통해 리턴받은 Output구조체의 필요한 stream을 sink하다가 Output이 발생하면 UI에 데이터 바인딩을 합니다.
```swift
output.articleDetail
            .sink { [weak self] article in
                guard let self else { return }
                self.hideLoading()

                self.setDatasource(blockTypes: article.blockTypes,
                                   isBookMarked: article.isMarked)
                self.applySnapshot(article.blockTypes)
            }
            .store(in: &cancelBag)
```

### DiffableDataSource를 따로 빼지 못한 이유
현재 아래 방식으로 DiffableDataSource를 만들어서 넣어주고 있습니다.
```swift
self.datasource = UITableViewDiffableDataSource(tableView: self.articleTableView,
                                                        cellProvider: { tableView, indexPath, itemIdentifier in
            switch itemIdentifier {
            case .thumbnail(let isMarked, let thumbnailModel):
                let cell = ThumnailTableViewCell.dequeueReusableCell(to: self.articleTableView)
                cell.inputData = thumbnailModel
                cell.selectionStyle = .none

                cell.bookMarkButton.tapPublisher
                    .sink { [weak self] _ in
                        cell.isMarked?.toggle()
                        self?.bookmarkButtonTapped.send(())
                    }
                    .store(in: &self.cancelBag)
                ...
```
UITableViewDiffableDataSource를 따로 클래스를 만들어서 하게 된다면 아래와 같이 할 수 있습니다.
```swift
final class ArticleDetailDataSource: UITableViewDiffableDataSource<MyPageSection, MyPageRow> {
    init(tableView: UITableView) {
        super.init(tableView: tableView) { tableView, indexPath, itemIdentifier in
             switch itemIdentifier {
            case .thumbnail(let isMarked, let thumbnailModel):
                let cell = ThumnailTableViewCell.dequeueReusableCell(to: self.articleTableView)
                cell.inputData = thumbnailModel
                cell.selectionStyle = .none

                cell.bookMarkButton.tapPublisher
                    .sink { [weak self] _ in
                        cell.isMarked?.toggle()
                        self?.bookmarkButtonTapped.send(())
                    }
                    .store(in: &self.cancelBag)
                ...
        }
    }
```

현재 cell내에 있는 button action을 delegate로 받지 않고  cell내에 public subject를 만들어서 해당 subject를 Observing하다가 버튼 액션이 발생하면 필요한 액션을 처리할 수 있게끔 구현했습니다. 문제는 `self`를 사용할 때 발생합니다. 

class의 2단계 초기화 과정으로 인해 super.init, 즉 부모의 초기화까지 모두 완료가 된 이후에 비로소 인스턴스가 초기화가 완료되고, 그 이후부터 self를 사용할 수 있습니다. 하지만 현재 self를 super.init안에서 사용하고 있기 때문에 인스턴스가 채 초기화되기 이전에 self를 사용하기 때문에 컴파일 에러가 나타나게 됩니다. 

결국 ViewController에 해당 DiffableDataSource에 대한 로직을 남겨두기로 했습니다.


## 📮 관련 이슈

- Resolved: #167 
