### PR TITLE
[REFACTOR] ArticleListByCategory Diffable 및 MVVM(Combine)-C 리팩토링 (#175)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -44,6 +44,10 @@
 		B520EA6E2A670C010027356E /* progressbar_5m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA652A670C010027356E /* progressbar_5m.json */; };
 		B5234F9B2B0A61D700D6EE58 /* ArticleDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */; };
 		B5234F9D2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */; };
+		B5234FA52B0B2C3700D6EE58 /* ArticleCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FA42B0B2C3700D6EE58 /* ArticleCategoryViewModel.swift */; };
+		B5234FA72B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FA62B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift */; };
+		B5234FA92B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FA82B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift */; };
+		B5234FAB2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FAA2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift */; };
 		B52C6BB42AF8AE1D008E3B99 /* Combine+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */; };
 		B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8312A5525C600F0DB19 /* AppDelegate.swift */; };
 		B532E8342A5525C600F0DB19 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8332A5525C600F0DB19 /* SceneDelegate.swift */; };
@@ -384,6 +388,10 @@
 		B520EA652A670C010027356E /* progressbar_5m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_5m.json; sourceTree = "<group>"; };
 		B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailViewModel.swift; sourceTree = "<group>"; };
 		B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailViewModelImpl.swift; sourceTree = "<group>"; };
+		B5234FA42B0B2C3700D6EE58 /* ArticleCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryViewModel.swift; sourceTree = "<group>"; };
+		B5234FA62B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryViewModelImpl.swift; sourceTree = "<group>"; };
+		B5234FA82B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryDiffableModel.swift; sourceTree = "<group>"; };
+		B5234FAA2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryDiffableDataSource.swift; sourceTree = "<group>"; };
 		B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+.swift"; sourceTree = "<group>"; };
 		B532E82E2A5525C600F0DB19 /* LionHeart-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "LionHeart-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B532E8312A5525C600F0DB19 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -785,6 +793,15 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		B5234FAC2B0B3F5600D6EE58 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B5234FA42B0B2C3700D6EE58 /* ArticleCategoryViewModel.swift */,
+				B5234FA62B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		B532E8252A5525C600F0DB19 = {
 			isa = PBXGroup;
 			children = (
@@ -1138,6 +1155,7 @@
 		B59892102A56B47C00CE1FEB /* ArticleCategory */ = {
 			isa = PBXGroup;
 			children = (
+				B5234FAC2B0B3F5600D6EE58 /* ViewModel */,
 				D3BA0B722A5CFA6400B6361F /* Model */,
 				B598922C2A56B6CA00CE1FEB /* Cells */,
 				B59892252A56B6A000CE1FEB /* ViewControllers */,
@@ -1767,7 +1785,9 @@
 		D3BA0B722A5CFA6400B6361F /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B5234FAA2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift */,
 				D3BA0B732A5CFA7B00B6361F /* ArticleCategoryModel.swift */,
+				B5234FA82B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2044,6 +2064,7 @@
 				C003CC6E2ADA51E200AFFAAC /* CurriculumListManager.swift in Sources */,
 				B53F4EFA2ADE3151001C5752 /* BookmarkAdaptor.swift in Sources */,
 				D35272D12A681E13002D7FCB /* ChallengeData.swift in Sources */,
+				B5234FAB2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift in Sources */,
 				C065F00D2ADBD29A0094912C /* OnboardingViewControllerable.swift in Sources */,
 				B59893132A5D3A4D00CE1FEB /* NetworkError.swift in Sources */,
 				C0DF03392A5A945D0037F740 /* UIViewController+.swift in Sources */,
@@ -2058,6 +2079,7 @@
 				C003CC512ADA4FA600AFFAAC /* CompleteOnboardingNavigation.swift in Sources */,
 				C09A33232A62D46300B40770 /* LHToastView.swift in Sources */,
 				B53F4EF82ADE2FB0001C5752 /* ChallengeCoordinatorImpl.swift in Sources */,
+				B5234FA92B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift in Sources */,
 				C06D23D22B04821B0048AFDB /* OnboardingViewModelImpl.swift in Sources */,
 				B5E78E152B05D38B00EA67A2 /* SplashViewModelImpl.swift in Sources */,
 				B532E8632A5529B000F0DB19 /* HTTPHeaderField.swift in Sources */,
@@ -2147,6 +2169,7 @@
 				C009E9F22ADBC23B00112F18 /* ChallengeFactory.swift in Sources */,
 				4A8980C52A611EE200746C58 /* MyPageProfileCollectionViewCell.swift in Sources */,
 				D3BA0B742A5CFA7B00B6361F /* ArticleCategoryModel.swift in Sources */,
+				B5234FA72B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift in Sources */,
 				C0DF033F2A5A959A0037F740 /* UIButton+.swift in Sources */,
 				C0B15E152AC011840058D56B /* LHLabel.swift in Sources */,
 				F4DB30B02A611C9700413EB9 /* CurriculumListByWeekData.swift in Sources */,
@@ -2227,6 +2250,7 @@
 				C003CC4F2ADA4F8D00AFFAAC /* OnboardingNavigation.swift in Sources */,
 				C034EE202ADE450600AD6FF3 /* ArticleCategoryCoordinator.swift in Sources */,
 				B59892E12A5AF39300CE1FEB /* LHNavigationBarView.swift in Sources */,
+				B5234FA52B0B2C3700D6EE58 /* ArticleCategoryViewModel.swift in Sources */,
 				C0F029E62A5FB9E000E0D185 /* ContainerView.swift in Sources */,
 				C0856B712ABFC0FB0026D9F8 /* ChallengeManagerImpl.swift in Sources */,
 				B52C6BB42AF8AE1D008E3B99 /* Combine+.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		B5234FA72B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FA62B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift */; };
 		B5234FA92B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FA82B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift */; };
 		B5234FAB2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FAA2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift */; };
+		B5234FAF2B0B405200D6EE58 /* ArticleListByCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FAE2B0B405200D6EE58 /* ArticleListByCategoryViewModel.swift */; };
+		B5234FB12B0B405900D6EE58 /* ArticleListByCategoryViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FB02B0B405900D6EE58 /* ArticleListByCategoryViewModelImpl.swift */; };
+		B5234FB32B0B451800D6EE58 /* ArticleListByCategoryDiffableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234FB22B0B451800D6EE58 /* ArticleListByCategoryDiffableModel.swift */; };
 		B52C6BB42AF8AE1D008E3B99 /* Combine+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */; };
 		B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8312A5525C600F0DB19 /* AppDelegate.swift */; };
 		B532E8342A5525C600F0DB19 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8332A5525C600F0DB19 /* SceneDelegate.swift */; };
@@ -392,6 +395,9 @@
 		B5234FA62B0B2D1F00D6EE58 /* ArticleCategoryViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryViewModelImpl.swift; sourceTree = "<group>"; };
 		B5234FA82B0B33CB00D6EE58 /* ArticleCategoryDiffableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryDiffableModel.swift; sourceTree = "<group>"; };
 		B5234FAA2B0B36DF00D6EE58 /* ArticleCategoryDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryDiffableDataSource.swift; sourceTree = "<group>"; };
+		B5234FAE2B0B405200D6EE58 /* ArticleListByCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListByCategoryViewModel.swift; sourceTree = "<group>"; };
+		B5234FB02B0B405900D6EE58 /* ArticleListByCategoryViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListByCategoryViewModelImpl.swift; sourceTree = "<group>"; };
+		B5234FB22B0B451800D6EE58 /* ArticleListByCategoryDiffableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListByCategoryDiffableModel.swift; sourceTree = "<group>"; };
 		B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+.swift"; sourceTree = "<group>"; };
 		B532E82E2A5525C600F0DB19 /* LionHeart-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "LionHeart-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B532E8312A5525C600F0DB19 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -802,6 +808,15 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		B5234FAD2B0B404500D6EE58 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B5234FAE2B0B405200D6EE58 /* ArticleListByCategoryViewModel.swift */,
+				B5234FB02B0B405900D6EE58 /* ArticleListByCategoryViewModelImpl.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		B532E8252A5525C600F0DB19 = {
 			isa = PBXGroup;
 			children = (
@@ -1124,8 +1139,10 @@
 		B598920C2A56B3B700CE1FEB /* ArticleListByCategory */ = {
 			isa = PBXGroup;
 			children = (
+				B5234FAD2B0B404500D6EE58 /* ViewModel */,
 				B59892122A56B52F00CE1FEB /* ViewControllers */,
 				B59892112A56B52B00CE1FEB /* Views */,
+				B5234FB22B0B451800D6EE58 /* ArticleListByCategoryDiffableModel.swift */,
 			);
 			path = ArticleListByCategory;
 			sourceTree = "<group>";
@@ -2025,6 +2042,7 @@
 				F435E0542A5E67BF0098E691 /* NSObject+.swift in Sources */,
 				4AE19A1F2A66F2E200C1DB7E /* BookmarkDetailCollectionViewCell.swift in Sources */,
 				D3AB54B62A625A7B0017BF53 /* ArticleListByCategoryHeaderView.swift in Sources */,
+				B5234FAF2B0B405200D6EE58 /* ArticleListByCategoryViewModel.swift in Sources */,
 				B59892E82A5B14FE00CE1FEB /* NavigationBarType.swift in Sources */,
 				B57BEB6E2A6275D600D1727C /* Serviceable.swift in Sources */,
 				D342807A2A67F12200DA1499 /* ChallengeDataResponse.swift in Sources */,
@@ -2117,6 +2135,7 @@
 				C003CC5E2ADA508A00AFFAAC /* LoginManager.swift in Sources */,
 				B5234F9B2B0A61D700D6EE58 /* ArticleDetailViewModel.swift in Sources */,
 				C065F00B2ADBD2800094912C /* LoginViewControllerable.swift in Sources */,
+				B5234FB12B0B405900D6EE58 /* ArticleListByCategoryViewModelImpl.swift in Sources */,
 				C06E38232A65353F00B00600 /* LoginType.swift in Sources */,
 				C0856B6B2ABFBC9D0026D9F8 /* ArticleDetailManagerImpl.swift in Sources */,
 				C0B15E272AC104D50058D56B /* LHImageButton.swift in Sources */,
@@ -2217,6 +2236,7 @@
 				B59BFD452ADBC08D005D2D81 /* MyPageControllerable.swift in Sources */,
 				C0F62FCA2A67CDCE0003ADFA /* BookmarkDetailCollectionViewCell.swift in Sources */,
 				C0DF03592A5A9BF80037F740 /* ArticleCategoryViewController.swift in Sources */,
+				B5234FB32B0B451800D6EE58 /* ArticleListByCategoryDiffableModel.swift in Sources */,
 				C00780BA2A60149D0043EB36 /* LHTodayArticleTitle.swift in Sources */,
 				B51220602A60111C006CBE2D /* Token.swift in Sources */,
 				C034EDD62ADE21BD00AD6FF3 /* SplashCoordinator.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		B520EA6C2A670C010027356E /* progressbar_2m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA632A670C010027356E /* progressbar_2m.json */; };
 		B520EA6D2A670C010027356E /* progressbar_3m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA642A670C010027356E /* progressbar_3m.json */; };
 		B520EA6E2A670C010027356E /* progressbar_5m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA652A670C010027356E /* progressbar_5m.json */; };
+		B5234F9B2B0A61D700D6EE58 /* ArticleDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */; };
+		B5234F9D2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */; };
 		B52C6BB42AF8AE1D008E3B99 /* Combine+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */; };
 		B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8312A5525C600F0DB19 /* AppDelegate.swift */; };
 		B532E8342A5525C600F0DB19 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8332A5525C600F0DB19 /* SceneDelegate.swift */; };
@@ -380,6 +382,8 @@
 		B520EA632A670C010027356E /* progressbar_2m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_2m.json; sourceTree = "<group>"; };
 		B520EA642A670C010027356E /* progressbar_3m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_3m.json; sourceTree = "<group>"; };
 		B520EA652A670C010027356E /* progressbar_5m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_5m.json; sourceTree = "<group>"; };
+		B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailViewModel.swift; sourceTree = "<group>"; };
+		B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailViewModelImpl.swift; sourceTree = "<group>"; };
 		B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+.swift"; sourceTree = "<group>"; };
 		B532E82E2A5525C600F0DB19 /* LionHeart-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "LionHeart-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B532E8312A5525C600F0DB19 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -772,6 +776,15 @@
 			path = Auth;
 			sourceTree = "<group>";
 		};
+		B5234F992B0A61CE00D6EE58 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B5234F9A2B0A61D700D6EE58 /* ArticleDetailViewModel.swift */,
+				B5234F9C2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		B532E8252A5525C600F0DB19 = {
 			isa = PBXGroup;
 			children = (
@@ -1082,6 +1095,7 @@
 		B598920B2A56B3A300CE1FEB /* ArticleDetail */ = {
 			isa = PBXGroup;
 			children = (
+				B5234F992B0A61CE00D6EE58 /* ViewModel */,
 				B5C6A2C92A5EF5210021BE5E /* Model */,
 				B598922B2A56B6C100CE1FEB /* Cells */,
 				B598922A2A56B6BE00CE1FEB /* Views */,
@@ -2079,6 +2093,7 @@
 				C0B15E292AC106CA0058D56B /* CurriculumListByCategoryTableView.swift in Sources */,
 				C003CC2F2AD9189F00AFFAAC /* MypageCoordinator.swift in Sources */,
 				C003CC5E2ADA508A00AFFAAC /* LoginManager.swift in Sources */,
+				B5234F9B2B0A61D700D6EE58 /* ArticleDetailViewModel.swift in Sources */,
 				C065F00B2ADBD2800094912C /* LoginViewControllerable.swift in Sources */,
 				C06E38232A65353F00B00600 /* LoginType.swift in Sources */,
 				C0856B6B2ABFBC9D0026D9F8 /* ArticleDetailManagerImpl.swift in Sources */,
@@ -2087,6 +2102,7 @@
 				C003CC272AD9185A00AFFAAC /* ArticleCategoryCoordinatorImpl.swift in Sources */,
 				C0DF03962A5B8FB10037F740 /* Palette.swift in Sources */,
 				C003CC682ADA51A700AFFAAC /* ArticleListByCategoryManager.swift in Sources */,
+				B5234F9D2B0A61DE00D6EE58 /* ArticleDetailViewModelImpl.swift in Sources */,
 				C003CC6A2ADA51C000AFFAAC /* MyPageManager.swift in Sources */,
 				4A3D72872A5D405C00A36189 /* BookmarkListCollectionViewCell.swift in Sources */,
 				C003CC622ADA50C000AFFAAC /* TodayManager.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Cells/ArticleCategoryCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Cells/ArticleCategoryCollectionViewCell.swift
@@ -20,7 +20,7 @@ final class ArticleCategoryCollectionViewCell: UICollectionViewCell, CollectionV
         didSet {
             guard let data = inputData else { return }
             categoryImageView.image = data.image
-            categoryInfoLabel.text = data.infoDdescription
+            categoryInfoLabel.text = data.infoDescription
         }
     }
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Model/ArticleCategoryDiffableDataSource.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Model/ArticleCategoryDiffableDataSource.swift
@@ -1,0 +1,24 @@
+//
+//  ArticleCategoryDiffableDataSource.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import UIKit
+
+
+final class ArticleCategoryDiffableDataSource: UICollectionViewDiffableDataSource<ArticleCategorySection, ArticleCategoryItem> {
+    
+    init(collectionView: UICollectionView) {
+        super.init(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .category(let title):
+                let cell = ArticleCategoryCollectionViewCell.dequeueReusableCell(to: collectionView, indexPath: indexPath)
+                cell.inputData = title
+                return cell
+            }
+        }
+    }
+    
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Model/ArticleCategoryDiffableModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Model/ArticleCategoryDiffableModel.swift
@@ -1,0 +1,17 @@
+//
+//  ArticleCategorySection.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+
+
+enum ArticleCategorySection {
+    case articleCategory
+}
+
+enum ArticleCategoryItem: Hashable {
+    case category(title: CategoryImage)
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Model/ArticleCategoryModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/Model/ArticleCategoryModel.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-struct CategoryImage: AppData {
+struct CategoryImage: Hashable, AppData {
     let image: UIImage
-    let infoDdescription: String
+    let infoDescription: String
     let categoryString: String
 }
 
@@ -17,14 +17,14 @@ extension CategoryImage {
 
     static func dummy() -> [CategoryImage] {
         return [
-            .init(image: ImageLiterals.ArticleCategory.budgetCategory, infoDdescription: "예산", categoryString: "BUDGET"),
-            .init(image: ImageLiterals.ArticleCategory.physicalCategory, infoDdescription: "신체 변화", categoryString: "PHYSICAL_CHANGE"),
-            .init(image: ImageLiterals.ArticleCategory.coupleCategory, infoDdescription: "부부 관계", categoryString: "MARITAL_RELATIONSHIP"),
-            .init(image: ImageLiterals.ArticleCategory.hospitalCategory, infoDdescription: "병원 정보", categoryString: "HOSPITAL_INFORMATION"),
-            .init(image: ImageLiterals.ArticleCategory.systemCategory, infoDdescription: "지원 제도", categoryString: "SUPPORT_SYSTEM"),
-            .init(image: ImageLiterals.ArticleCategory.prenatalCategory, infoDdescription: "태교", categoryString: "PRENATAL_EDUCATION"),
-            .init(image: ImageLiterals.ArticleCategory.babyProductCategory, infoDdescription: "아기 용품", categoryString: "BABY_GOODS"),
-            .init(image: ImageLiterals.ArticleCategory.daddyTipCategory, infoDdescription: "아빠들의 팁", categoryString: "DAD_TIPS")
+            .init(image: ImageLiterals.ArticleCategory.budgetCategory, infoDescription: "예산", categoryString: "BUDGET"),
+            .init(image: ImageLiterals.ArticleCategory.physicalCategory, infoDescription: "신체 변화", categoryString: "PHYSICAL_CHANGE"),
+            .init(image: ImageLiterals.ArticleCategory.coupleCategory, infoDescription: "부부 관계", categoryString: "MARITAL_RELATIONSHIP"),
+            .init(image: ImageLiterals.ArticleCategory.hospitalCategory, infoDescription: "병원 정보", categoryString: "HOSPITAL_INFORMATION"),
+            .init(image: ImageLiterals.ArticleCategory.systemCategory, infoDescription: "지원 제도", categoryString: "SUPPORT_SYSTEM"),
+            .init(image: ImageLiterals.ArticleCategory.prenatalCategory, infoDescription: "태교", categoryString: "PRENATAL_EDUCATION"),
+            .init(image: ImageLiterals.ArticleCategory.babyProductCategory, infoDescription: "아기 용품", categoryString: "BABY_GOODS"),
+            .init(image: ImageLiterals.ArticleCategory.daddyTipCategory, infoDescription: "아빠들의 팁", categoryString: "DAD_TIPS")
         ]
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewModel/ArticleCategoryViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewModel/ArticleCategoryViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  ArticleCategoryViewModel.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+protocol ArticleCategoryViewModelPresentable {}
+
+protocol ArticleCategoryViewModel: ViewModel where Input == ArticleCategoryViewModelInput, Output == ArticleCategoryViewModelOutput {}
+
+struct ArticleCategoryViewModelInput {
+    let viewWillAppear: PassthroughSubject<Void, Never>
+    let bookMarkButtonTapped: PassthroughSubject<Void, Never>
+    let myPageButtonTapped: PassthroughSubject<Void, Never>
+    let categoryCellTapped: PassthroughSubject<IndexPath, Never>
+}
+
+struct ArticleCategoryViewModelOutput {
+    let categoryTitle: AnyPublisher<[CategoryImage], Never>
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewModel/ArticleCategoryViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewModel/ArticleCategoryViewModelImpl.swift
@@ -1,0 +1,76 @@
+//
+//  ArticleCategoryViewModelImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+final class ArticleCategoryViewModelImpl: ArticleCategoryViewModel, ArticleCategoryViewModelPresentable {
+    
+    private enum FlowType {
+        case bookmark
+        case myPage
+        case category(title: String)
+    }
+    
+    private let navigator: ArticleCategoryNavigation
+    
+    private let categoryTitles = CategoryImage.dummy()
+    
+    private let navigationSubject = PassthroughSubject<FlowType, Never>()
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    init(navigator: ArticleCategoryNavigation) {
+        self.navigator = navigator
+    }
+    
+    func transform(input: ArticleCategoryViewModelInput) -> ArticleCategoryViewModelOutput {
+        
+        navigationSubject
+            .receive(on: RunLoop.main)
+            .sink { flow in
+                switch flow {
+                case .bookmark:
+                    self.navigator.navigationLeftButtonTapped()
+                case .myPage:
+                    self.navigator.navigationRightButtonTapped()
+                case .category(let title):
+                    self.navigator.articleListCellTapped(categoryName: title)
+                }
+            }
+            .store(in: &cancelBag)
+        
+        input.bookMarkButtonTapped
+            .sink { _ in
+                self.navigationSubject.send(.bookmark)
+            }
+            .store(in: &cancelBag)
+        
+        input.categoryCellTapped
+            .sink { [weak self] indexPath in
+                guard let self else { return }
+                let title = self.categoryTitles[indexPath.row].categoryString
+                self.navigationSubject.send(.category(title: title))
+            }
+            .store(in: &cancelBag)
+        
+        input.myPageButtonTapped
+            .sink { _ in
+                self.navigationSubject.send(.myPage)
+            }
+            .store(in: &cancelBag)
+        
+        let categoryTitles = input.viewWillAppear
+            .map { _ in
+                return CategoryImage.dummy()
+            }
+            .eraseToAnyPublisher()
+        
+        return Output(categoryTitle: categoryTitles)
+    }
+}
+

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Cells/ThumnailTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Cells/ThumnailTableViewCell.swift
@@ -15,9 +15,9 @@ final class ThumnailTableViewCell: UITableViewCell, TableViewCellRegisterDequeue
     private let gradientImageView = LHImageView(in: ImageLiterals.Curriculum.gradient, contentMode: .scaleAspectFill)
     private let thumbnailImageView = LHImageView(contentMode: .scaleAspectFill)
     private let imageCaptionLabel = LHLabel(type: .body4, color: .gray500)
-    private lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkBig, select: ImageLiterals.BookMark.activeBookmarkBig)
+    lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkBig, select: ImageLiterals.BookMark.activeBookmarkBig)
 
-    var bookmarkButtonDidTap: ((Bool) -> Void)?
+//    var bookmarkButtonDidTap: ((Bool) -> Void)?
     var inputData: ArticleBlockData? {
         didSet {
             configureCell(inputData)
@@ -95,11 +95,11 @@ private extension ThumnailTableViewCell {
     }
     
     func setAddTarget() {
-        bookMarkButton.addButtonAction { [weak self] _ in
-            guard let self else { return }
-            self.isSelected.toggle()
-            self.bookmarkButtonDidTap?(self.isSelected)
-        }
+//        bookMarkButton.addButtonAction { [weak self] _ in
+//            guard let self else { return }
+//            self.isSelected.toggle()
+//            self.bookmarkButtonDidTap?(self.isSelected)
+//        }
     }
 }
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Model/ArticleBlockType.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Model/ArticleBlockType.swift
@@ -7,15 +7,20 @@
 
 import UIKit
 
+// MARK: - Section
+enum ArticleDetailSection {
+    case articleMain
+}
+
 // MARK: - AppData
 
-struct ArticleBlockData: AppData {
+struct ArticleBlockData: Hashable, AppData {
     let content: String
     let caption: String?
 }
 
 @frozen
-enum BlockTypeAppData {
+enum BlockTypeAppData: Hashable {
     case thumbnail(isMarked: Bool, model: ArticleBlockData)
     case articleTitle(model: ArticleBlockData)
     case editorNote(model: ArticleBlockData)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -7,14 +7,27 @@
 //
 
 import UIKit
+import Combine
 
 import SnapKit
 
 final class ArticleDetailViewController: UIViewController, ArticleControllerable {
     
-    // MARK: - UI Components
-    var adaptor: ArticleDetailModalNavigation
-    private let manager: ArticleDetailManager
+    
+    private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
+    
+    private let closeButtonTapped = PassthroughSubject<Void, Never>()
+    
+    private let bookmarkButtonTapped = PassthroughSubject<Void, Never>()
+    
+    private let viewModel: any ArticleDetailViewModel
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    private var datasource: UITableViewDiffableDataSource<ArticleDetailSection, BlockTypeAppData>!
+    
+//    var adaptor: ArticleDetailModalNavigation
+//    private let manager: ArticleDetailManager
     
     private lazy var navigationBar = LHNavigationBarView(type: .articleMain, viewController: self)
     
@@ -26,27 +39,26 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
 
     // MARK: - Properties
 
-    private var isBookMarked: Bool? {
-        didSet {
-            guard let isBookMarked else { return }
-            LHToast.show(message: isBookMarked ? "북마크가 추가되었습니다" : "북마크가 해제되었습니다")
-        }
-    }
+//    private var isBookMarked: Bool? {
+//        didSet {
+//            guard let isBookMarked else { return }
+//            LHToast.show(message: isBookMarked ? "북마크가 추가되었습니다" : "북마크가 해제되었습니다")
+//        }
+//    }
+//
+//    private var articleDatas: [BlockTypeAppData]? {
+//        didSet {
+//            self.articleTableView.reloadData()
+//            hideLoading()
+//        }
+//    }
 
-    private var articleDatas: [BlockTypeAppData]? {
-        didSet {
-            self.articleTableView.reloadData()
-            hideLoading()
-        }
-    }
-
-    private var articleId: Int?
+//    private var articleId: Int?
 
     private var contentOffsetY: CGFloat = 0
     
-    init(manager: ArticleDetailManager, adaptor: ArticleDetailModalNavigation) {
-        self.manager = manager
-        self.adaptor = adaptor
+    init(viewModel: some ArticleDetailViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -60,54 +72,167 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
         setUI()
         setHierarchy()
         setLayout()
-        setAddTarget()
         setTableView()
         setNavigationBar()
         setTabbar()
+        bindInput()
+        bind()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        viewWillAppearSubject.send(())
         showLoading()
-        getArticleDetail()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.tabBarController?.tabBar.isHidden = false
     }
+    
+    private func bindInput() {
+        scrollToTopButton.tapPublisher
+            .sink { [weak self] _ in
+                guard let self else { return }
+                let indexPath = IndexPath(row: 0, section: 0)
+                self.articleTableView.scrollToRow(at: indexPath, at: .top, animated: true)
+                self.scrollToTopButton.isHidden = true
+            }
+            .store(in: &cancelBag)
+        
+        navigationBar.leftBarItem.tapPublisher
+            .sink { _ in
+                self.closeButtonTapped.send(())
+            }
+            .store(in: &cancelBag)
+    }
+    
+    private func bind() {
+        let input = ArticleDetailViewModelInput(viewWillAppear: viewWillAppearSubject,
+                                                closeButtonTapped: closeButtonTapped,
+                                                bookmarkButtonTapped: bookmarkButtonTapped)
+        let output = viewModel.transform(input: input)
+        output.articleDetail
+            .sink { [weak self] result in
+                guard let self else { return }
+                self.hideLoading()
+                
+                switch result {
+                case .success(let article):
+                    //TODO: - DataSource apply snapshot
+                    self.setDatasource(blockTypes: article.blockTypes,
+                                       isBookMarked: article.isMarked)
+                    self.applySnapshot(article.blockTypes)
+                case .failure(let error):
+                    print(error.description)
+                }
+            }
+            .store(in: &cancelBag)
+    }
 }
-
-// MARK: - Network
 
 extension ArticleDetailViewController {
-    private func getArticleDetail() {
-        Task {
-            do {
-                guard let articleId else { return }
-                self.articleDatas = try await manager.getArticleDetail(articleId: articleId)
-            } catch {
-                guard let error = error as? NetworkError else { return }
-                handleError(error)
+    private func setDatasource(blockTypes: [BlockTypeAppData], isBookMarked: Bool) {
+        self.datasource = UITableViewDiffableDataSource(tableView: self.articleTableView,
+                                                        cellProvider: { tableView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .thumbnail(let isMarked, let thumbnailModel):
+                let cell = ThumnailTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = thumbnailModel
+                cell.selectionStyle = .none
+                
+                cell.bookMarkButton.tapPublisher
+                    .sink { [weak self] _ in
+                        self?.bookmarkButtonTapped.send(())
+                    }
+                    .store(in: &self.cancelBag)
+
+                if isBookMarked {
+                    cell.isMarked = isBookMarked
+                } else {
+                    cell.isMarked = isMarked
+                }
+                cell.setThumbnailImageView()
+                return cell
+            case .articleTitle(let titleModel):
+                let cell = TitleTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = titleModel
+                cell.selectionStyle = .none
+                return cell
+            case .editorNote(let editorModel):
+                let cell = EditorTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = editorModel
+                cell.selectionStyle = .none
+                return cell
+            case .chapterTitle(let chapterTitleModel):
+                let cell = ChapterTitleTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = chapterTitleModel
+                cell.selectionStyle = .none
+                return cell
+            case .body(let bodyModel):
+                let cell = BodyTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = bodyModel
+                cell.selectionStyle = .none
+                return cell
+            case .generalTitle(let generalTitleModel):
+                let cell = GeneralTitleTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = generalTitleModel
+                cell.selectionStyle = .none
+                return cell
+            case .image(let imageModel):
+                let cell = ThumnailTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.inputData = imageModel
+                cell.setImageTypeCell()
+                cell.selectionStyle = .none
+                return cell
+            case .endNote:
+                let cell = CopyRightTableViewCell.dequeueReusableCell(to: self.articleTableView)
+                cell.selectionStyle = .none
+                return cell
+            case .none:
+                return UITableViewCell()
             }
-        }
+        })
     }
-
-    private func articleBookMark(articleId: Int, isSelected: Bool) {
-        Task {
-            do {
-                let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
-                try await manager.postBookmark(model: bookmarkRequest)
-
-                isBookMarked = isSelected
-            } catch {
-                guard let error = error as? NetworkError else { return }
-                self.handleError(error)
-            }
-        }
-
+    
+    func applySnapshot(_ blocks: [BlockTypeAppData]) {
+        var snapshot = NSDiffableDataSourceSnapshot<ArticleDetailSection, BlockTypeAppData>()
+        snapshot.appendSections([.articleMain])
+        snapshot.appendItems(blocks)
+        self.datasource.apply(snapshot, animatingDifferences: false)
     }
 }
+
+//// MARK: - Network
+//
+//extension ArticleDetailViewController {
+//    private func getArticleDetail() {
+//        Task {
+//            do {
+//                guard let articleId else { return }
+//                self.articleDatas = try await manager.getArticleDetail(articleId: articleId)
+//            } catch {
+//                guard let error = error as? NetworkError else { return }
+//                handleError(error)
+//            }
+//        }
+//    }
+//
+//    private func articleBookMark(articleId: Int, isSelected: Bool) {
+//        Task {
+//            do {
+//                let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
+//                try await manager.postBookmark(model: bookmarkRequest)
+//
+//                isBookMarked = isSelected
+//            } catch {
+//                guard let error = error as? NetworkError else { return }
+//                self.handleError(error)
+//            }
+//        }
+//
+//    }
+//}
 
 //extension ArticleDetailViewController: ViewControllerServiceable {
 //    func handleError(_ error: NetworkError) {
@@ -163,7 +288,7 @@ private extension ArticleDetailViewController {
 
     func setTableView() {
         articleTableView.delegate = self
-        articleTableView.dataSource = self
+//        articleTableView.dataSource = self
     }
 
     func setNavigationBar() {
@@ -172,18 +297,6 @@ private extension ArticleDetailViewController {
     
     func setTabbar() {
         self.tabBarController?.tabBar.isHidden = true
-    }
-
-    func setAddTarget() {
-        navigationBar.backButtonAction {
-            self.adaptor.closeButtonTapped()
-        }
-        
-        scrollToTopButton.addButtonAction { _ in
-            let indexPath = IndexPath(row: 0, section: 0)
-            self.articleTableView.scrollToRow(at: indexPath, at: .top, animated: true)
-            self.scrollToTopButton.isHidden = true
-        }
     }
 }
 
@@ -205,79 +318,85 @@ extension ArticleDetailViewController: UITableViewDelegate {
 
 }
 
-extension ArticleDetailViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return articleDatas?.count ?? 0
-    }
+//extension ArticleDetailViewController: UITableViewDataSource {
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return articleDatas?.count ?? 0
+//    }
+//
+//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//        guard let articleDatas else { return UITableViewCell() }
+//
+//        switch articleDatas[indexPath.row] {
+//        case .thumbnail(let isMarked, let thumbnailModel):
+//            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = thumbnailModel
+//            cell.selectionStyle = .none
+//            cell.bookMarkButton.tapPublisher
+//                .sink { [weak self] _ in
+//                    self?.bookmarkButtonTapped.send(())
+//                }
+//                .store(in: &cancelBag)
+//                
+////            cell.bookmarkButtonDidTap = { isSelected in
+////                guard let articleId = self.articleId else { return }
+////
+////                self.articleBookMark(articleId: articleId, isSelected: isSelected)
+////            }
+//
+//            if let isBookMarked {
+//                cell.isMarked = isBookMarked
+//            } else {
+//                cell.isMarked = isMarked
+//            }
+//            cell.setThumbnailImageView()
+//            return cell
+//        case .articleTitle(let titleModel):
+//            let cell = TitleTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = titleModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .editorNote(let editorModel):
+//            let cell = EditorTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = editorModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .chapterTitle(let chapterTitleModel):
+//            let cell = ChapterTitleTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = chapterTitleModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .body(let bodyModel):
+//            let cell = BodyTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = bodyModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .generalTitle(let generalTitleModel):
+//            let cell = GeneralTitleTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = generalTitleModel
+//            cell.selectionStyle = .none
+//            return cell
+//        case .image(let imageModel):
+//            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.inputData = imageModel
+//            cell.setImageTypeCell()
+//            cell.selectionStyle = .none
+//            return cell
+//        case .endNote:
+//            let cell = CopyRightTableViewCell.dequeueReusableCell(to: articleTableView)
+//            cell.selectionStyle = .none
+//            return cell
+//        case .none:
+//            return UITableViewCell()
+//        }
+//    }
+//
+//}
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let articleDatas else { return UITableViewCell() }
 
-        switch articleDatas[indexPath.row] {
-        case .thumbnail(let isMarked, let thumbnailModel):
-            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = thumbnailModel
-            cell.selectionStyle = .none
-            cell.bookmarkButtonDidTap = { isSelected in
-                guard let articleId = self.articleId else { return }
-
-                self.articleBookMark(articleId: articleId, isSelected: isSelected)
-            }
-
-            if let isBookMarked {
-                cell.isMarked = isBookMarked
-            } else {
-                cell.isMarked = isMarked
-            }
-            cell.setThumbnailImageView()
-            return cell
-        case .articleTitle(let titleModel):
-            let cell = TitleTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = titleModel
-            cell.selectionStyle = .none
-            return cell
-        case .editorNote(let editorModel):
-            let cell = EditorTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = editorModel
-            cell.selectionStyle = .none
-            return cell
-        case .chapterTitle(let chapterTitleModel):
-            let cell = ChapterTitleTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = chapterTitleModel
-            cell.selectionStyle = .none
-            return cell
-        case .body(let bodyModel):
-            let cell = BodyTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = bodyModel
-            cell.selectionStyle = .none
-            return cell
-        case .generalTitle(let generalTitleModel):
-            let cell = GeneralTitleTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = generalTitleModel
-            cell.selectionStyle = .none
-            return cell
-        case .image(let imageModel):
-            let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.inputData = imageModel
-            cell.setImageTypeCell()
-            cell.selectionStyle = .none
-            return cell
-        case .endNote:
-            let cell = CopyRightTableViewCell.dequeueReusableCell(to: articleTableView)
-            cell.selectionStyle = .none
-            return cell
-        case .none:
-            return UITableViewCell()
-        }
-    }
-
-}
-
-
-extension ArticleDetailViewController {
-    /// Article ID를 해당 메서드로 넘긴 후에 해당 VC를 present해주세요
-    /// - Parameter id: articleId
-    func setArticleId(id: Int?) {
-        self.articleId = id
-    }
-}
+//extension ArticleDetailViewController {
+//    /// Article ID를 해당 메서드로 넘긴 후에 해당 VC를 present해주세요
+//    /// - Parameter id: articleId
+//    func setArticleId(id: Int?) {
+//        self.articleId = id
+//    }
+//}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -128,6 +128,12 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
                 }
             }
             .store(in: &cancelBag)
+        
+        output.bookmarkCompleted
+            .sink { str in
+                print(str)
+            }
+            .store(in: &cancelBag)
     }
 }
 
@@ -143,6 +149,7 @@ extension ArticleDetailViewController {
                 
                 cell.bookMarkButton.tapPublisher
                     .sink { [weak self] _ in
+                        cell.isMarked?.toggle()
                         self?.bookmarkButtonTapped.send(())
                     }
                     .store(in: &self.cancelBag)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  ArticleDetailViewModel.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+protocol ArticleDetailViewModelPresentable {
+    func setArticleId(id: Int)
+}
+
+protocol ArticleDetailViewModel: ViewModel where Input == ArticleDetailViewModelInput, Output == ArticleDetailViewModelOutput {}
+
+struct ArticleDetailViewModelInput {
+    let viewWillAppear: PassthroughSubject<Void, Never>
+    let closeButtonTapped: PassthroughSubject<Void, Never>
+    let bookmarkButtonTapped: PassthroughSubject<Void, Never>
+}
+
+struct ArticleDetailViewModelOutput {
+    let articleDetail: AnyPublisher<Result<Article, NetworkError>, Never>
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
@@ -18,9 +18,11 @@ struct ArticleDetailViewModelInput {
     let viewWillAppear: PassthroughSubject<Void, Never>
     let closeButtonTapped: PassthroughSubject<Void, Never>
     let bookmarkButtonTapped: PassthroughSubject<Void, Never>
+    let scrollToTopButtonTapped: PassthroughSubject<Void, Never>
 }
 
 struct ArticleDetailViewModelOutput {
-    let articleDetail: AnyPublisher<Result<Article, NetworkError>, Never>
+    let articleDetail: AnyPublisher<Article, Never>
     let bookmarkCompleted: AnyPublisher<String, Never>
+    let scrollToTopButtonTapped: AnyPublisher<Void, Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModel.swift
@@ -22,4 +22,5 @@ struct ArticleDetailViewModelInput {
 
 struct ArticleDetailViewModelOutput {
     let articleDetail: AnyPublisher<Result<Article, NetworkError>, Never>
+    let bookmarkCompleted: AnyPublisher<String, Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewModel/ArticleDetailViewModelImpl.swift
@@ -1,0 +1,144 @@
+//
+//  ArticleDetailViewModelImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+struct Article {
+    let blockTypes: [BlockTypeAppData]
+    let isMarked: Bool
+}
+
+final class ArticleDetailViewModelImpl: ArticleDetailViewModel, ArticleDetailViewModelPresentable {
+    
+    private enum FlowType {
+        case closeButtonTapped
+        case expired
+    }
+    
+    private var adaptor: ArticleDetailModalNavigation
+    private let manager: ArticleDetailManager
+    
+    private let navigationSubject = PassthroughSubject<FlowType, Never>()
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    private var isBookMarked: Bool?
+//    {
+//        didSet {
+//            guard let isBookMarked else { return }
+//            LHToast.show(message: isBookMarked ? "북마크가 추가되었습니다" : "북마크가 해제되었습니다")
+//        }
+//    }
+
+    private var articleDatas: [BlockTypeAppData]?
+//    {
+//        didSet {
+//            self.articleTableView.reloadData()
+//            hideLoading()
+//        }
+//    }
+    
+    private var articleId: Int?
+    
+    init(adaptor: ArticleDetailModalNavigation, manager: ArticleDetailManager) {
+        self.adaptor = adaptor
+        self.manager = manager
+    }
+    
+    func transform(input: ArticleDetailViewModelInput) -> ArticleDetailViewModelOutput {
+        
+        navigationSubject
+            .receive(on: RunLoop.main)
+            .sink { [weak self] flow in
+                guard let self else { return }
+                switch flow {
+                case .closeButtonTapped:
+                    self.adaptor.closeButtonTapped()
+                case .expired:
+                    self.adaptor.checkTokenIsExpired()
+                }
+            }
+            .store(in: &cancelBag)
+        
+        input.closeButtonTapped
+            .sink { [weak self] _ in
+                self?.navigationSubject.send(.closeButtonTapped)
+            }
+            .store(in: &cancelBag)
+        
+        
+        let articleBlockTypes = input.viewWillAppear
+            .flatMap { _ -> AnyPublisher<Result<Article, NetworkError>, Never> in
+                return Future<Result<Article, NetworkError>, NetworkError> { promise in
+                    Task {
+                        do {
+                            guard let articleId = self.articleId else { return }
+                            let articleBlocks = try await self.getArticleDetail(articleId: articleId)
+                            let thumbnail = articleBlocks[0]
+                            if case .thumbnail(let isMarked, _) = thumbnail {
+                                self.isBookMarked = isMarked
+                                promise(.success(.success(Article(blockTypes: articleBlocks, isMarked: isMarked))))
+                            }
+                        } catch {
+                            guard let error = error as? NetworkError else { return }
+                            self.handleError(error)
+                        }
+                    }
+                }
+                .catch { error in
+                    return Just(.failure(error))
+                }
+                .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+        
+        
+        return Output(articleDetail: articleBlockTypes)
+    }
+    
+}
+
+// MARK: - Network
+
+extension ArticleDetailViewModelImpl {
+    private func getArticleDetail(articleId: Int) async throws -> [BlockTypeAppData] {
+        return try await manager.getArticleDetail(articleId: articleId)
+    }
+
+    private func articleBookMark(articleId: Int, isSelected: Bool) {
+        Task {
+            do {
+                let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
+                try await manager.postBookmark(model: bookmarkRequest)
+
+                isBookMarked = isSelected
+            } catch {
+                guard let error = error as? NetworkError else { return }
+                self.handleError(error)
+            }
+        }
+
+    }
+}
+
+extension ArticleDetailViewModelImpl {
+    func handleError(_ error: NetworkError) {
+        if case .unAuthorizedError = error {
+            self.navigationSubject.send(.expired)
+        }
+    }
+}
+
+
+extension ArticleDetailViewModelImpl {
+    /// Article ID를 해당 메서드로 넘긴 후에 해당 VC를 present해주세요
+    /// - Parameter id: articleId
+    func setArticleId(id: Int) {
+        self.articleId = id
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ArticleListByCategoryDiffableModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ArticleListByCategoryDiffableModel.swift
@@ -1,0 +1,17 @@
+//
+//  ArticleListByCategoryDiffableModel.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+
+
+enum ArticleListByCategorySection {
+    case article
+}
+
+enum ArticleListByCategoryItem: Hashable {
+    case article(data: ArticleDataByWeek)
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -7,27 +7,29 @@
 //
 
 import UIKit
+import Combine
 
 import SnapKit
 
 final class ArticleListByCategoryViewController: UIViewController, ArticleListByCategoryViewControllerable {
     
-    var navigator: ArticleListByCategoryNavigation
-    private let manager: ArticleListByCategoryManager
+    private let viewWillAppear = PassthroughSubject<Void, Never>()
+    private let backButtonTapped = PassthroughSubject<Void, Never>()
+    private let bookmarkTapped = PassthroughSubject<(isSelected: Bool, indexPath: IndexPath), Never>()
+    private let articleCellTapped = PassthroughSubject<IndexPath, Never>()
     
     private lazy var navigationBar = LHNavigationBarView(type: .exploreEachCategory, viewController: self)
+    
     private let articleListTableView = ArticleListTableView()
     
-    var categoryString: String?
-    var articleListData: [ArticleDataByWeek] = [] {
-        didSet {
-            articleListTableView.reloadData()
-        }
-    }
+    private let viewModel: any ArticleListByCategoryViewModel
     
-    init(manager: ArticleListByCategoryManager, navigator: ArticleListByCategoryNavigation) {
-        self.manager = manager
-        self.navigator = navigator
+    private var datasource: UITableViewDiffableDataSource<ArticleListByCategorySection, ArticleListByCategoryItem>!
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    init(viewModel: some ArticleListByCategoryViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -42,23 +44,76 @@ final class ArticleListByCategoryViewController: UIViewController, ArticleListBy
         setLayout()
         setDelegate()
         setTableView()
-        setAddTarget()
+        bindInput()
+        bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         showLoading()
-        Task {
-            do {
-                guard let categoryString else { return }
-                self.articleListData = try await manager.getArticleListByCategory(categoryString: categoryString).articleData
-                self.articleListTableView.reloadData()
-                hideLoading()
-            } catch {
-                guard let error = error as? NetworkError else { return }
-                handleError(error)
+        viewWillAppear.send(())
+    }
+    
+    func bindInput() {
+        navigationBar.leftBarItem
+            .tapPublisher
+            .sink { _ in
+                self.backButtonTapped.send(())
             }
+            .store(in: &cancelBag)
+    }
+    
+    func bind() {
+        let input = ArticleListByCategoryViewModelInput(viewWillAppear: viewWillAppear,
+                                                        backButtonTapped: backButtonTapped,
+                                                        bookmarkTapped: bookmarkTapped,
+                                                        articleCellTapped: articleCellTapped)
+        let output = viewModel.transform(input: input)
+        output.bookmarkCompleted
+            .sink { message in
+                print(message)
+            }
+            .store(in: &cancelBag)
+        
+        output.articles
+            .sink { [weak self] articleDatas in
+                guard let self else { return }
+                self.setDataSource()
+                self.applySnapshot(articleDatas: articleDatas)
+            }
+            .store(in: &cancelBag)
+    }
+}
+
+extension ArticleListByCategoryViewController {
+    func setDataSource() {
+        self.datasource = UITableViewDiffableDataSource(tableView: self.articleListTableView, cellProvider: { tableView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .article(let articleData):
+                let cell = CurriculumArticleByWeekTableViewCell.dequeueReusableCell(to: self.articleListTableView)
+                cell.inputData = articleData
+                cell.selectionStyle = .none
+                
+                cell.bookMarkButton.tapPublisher
+                    .sink { [weak self] _ in
+                        self?.bookmarkTapped.send((isSelected: cell.isSelected, indexPath: indexPath))
+                    }
+                    .store(in: &self.cancelBag)
+                return cell
+            }
+        })
+    }
+    
+    func applySnapshot(articleDatas: [ArticleDataByWeek]) {
+        var snapshot = NSDiffableDataSourceSnapshot<ArticleListByCategorySection, ArticleListByCategoryItem>()
+        snapshot.appendSections([.article])
+        
+        let items = articleDatas.map {
+            return ArticleListByCategoryItem.article(data: $0)
         }
+        
+        snapshot.appendItems(items, toSection: .article)
+        self.datasource.apply(snapshot)
     }
 }
 
@@ -85,69 +140,16 @@ private extension ArticleListByCategoryViewController {
     }
     
     func setDelegate() {
-        articleListTableView.dataSource = self
         articleListTableView.delegate = self
     }
     
     func setTableView() {
         CurriculumArticleByWeekTableViewCell.register(to: articleListTableView)
     }
-    
-    func setAddTarget() {
-        navigationBar.backButtonAction {
-            self.navigator.backButtonTapped()
-        }
-    }
-}
-
-//extension ArticleListByCategoryViewController: ViewControllerServiceable {
-//    func handleError(_ error: NetworkError) {
-//        switch error {
-//        case .urlEncodingError:
-//            LHToast.show(message: "URL Error")
-//        case .jsonDecodingError:
-//            LHToast.show(message: "Decoding Error")
-//        case .badCasting:
-//            LHToast.show(message: "Bad Casting")
-//        case .fetchImageError:
-//            LHToast.show(message: "Image Error")
-//        case .unAuthorizedError:
-//            navigator.checkTokenIsExpired()
-//        case .clientError(_, let message):
-//            LHToast.show(message: message)
-//        case .serverError:
-//            LHToast.show(message: error.description)
-//        }
-//    }
-//}
-
-extension ArticleListByCategoryViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return articleListData.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = CurriculumArticleByWeekTableViewCell.dequeueReusableCell(to: articleListTableView)
-        cell.inputData = articleListData[indexPath.row]
-        cell.selectionStyle = .none
-        cell.bookMarkButtonTapped = { isSelected, indexPath in
-            Task {
-                do {
-                    try await self.manager.postBookmark(model: BookmarkRequest(articleId: self.articleListData[indexPath.row].articleId,
-                                                                                  bookmarkRequestStatus: isSelected))
-                    isSelected ? LHToast.show(message: "북마크에 추가되었습니다", isTabBar: true) : LHToast.show(message: "북마크에 해제되었습니다", isTabBar: true)
-                } catch {
-                    guard let error = error as? NetworkError else { return }
-                    self.handleError(error)
-                }
-            }
-        }
-        return cell
-    }
 }
 
 extension ArticleListByCategoryViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        self.navigator.articleListByCategoryCellTapped(articleID: articleListData[indexPath.row].articleId)
+        self.articleCellTapped.send(indexPath)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewModel/ArticleListByCategoryViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewModel/ArticleListByCategoryViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  ArticleListByCategoryViewModel.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+protocol ArticleListByCategoryViewModelPresentable {
+    func setCategoryTitle(title: String)
+}
+
+protocol ArticleListByCategoryViewModel: ViewModel where Input == ArticleListByCategoryViewModelInput, Output == ArticleListByCategoryViewModelOutput {}
+
+struct ArticleListByCategoryViewModelInput {
+    let viewWillAppear: PassthroughSubject<Void, Never>
+    let backButtonTapped: PassthroughSubject<Void, Never>
+    let bookmarkTapped: PassthroughSubject<(isSelected: Bool, indexPath: IndexPath), Never>
+    let articleCellTapped: PassthroughSubject<IndexPath, Never>
+}
+
+struct ArticleListByCategoryViewModelOutput {
+    let articles: AnyPublisher<[ArticleDataByWeek], Never>
+    let bookmarkCompleted: AnyPublisher<String, Never>
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewModel/ArticleListByCategoryViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewModel/ArticleListByCategoryViewModelImpl.swift
@@ -1,0 +1,148 @@
+//
+//  ArticleListByCategoryViewModelImpl.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 11/20/23.
+//
+
+import Foundation
+import Combine
+
+final class ArticleListByCategoryViewModelImpl: ArticleListByCategoryViewModel & ArticleListByCategoryViewModelPresentable {
+    
+    private enum FlowType {
+        case article(articleId: Int)
+        case backButton
+        case expire
+    }
+    
+    private let navigator: ArticleListByCategoryNavigation
+    private let manager: ArticleListByCategoryManager
+    
+    var categoryString: String?
+    var articleListData: [ArticleDataByWeek]?
+    
+    private let navigationSubject = PassthroughSubject<FlowType, Never>()
+    private let errorSubject = PassthroughSubject<NetworkError, Never>()
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    init(navigator: ArticleListByCategoryNavigation, manager: ArticleListByCategoryManager) {
+        self.navigator = navigator
+        self.manager = manager
+    }
+    
+    func transform(input: ArticleListByCategoryViewModelInput) -> ArticleListByCategoryViewModelOutput {
+        
+        errorSubject
+            .sink { error in
+                print(error)
+            }
+            .store(in: &cancelBag)
+        
+        navigationSubject
+            .receive(on: RunLoop.main)
+            .sink { flow in
+                switch flow {
+                case .article(let articleID):
+                    self.navigator.articleListByCategoryCellTapped(articleID: articleID)
+                case .backButton:
+                    self.navigator.backButtonTapped()
+                case .expire:
+                    self.navigator.checkTokenIsExpired()
+                }
+            }
+            .store(in: &cancelBag)
+        
+        let articleDatas = input.viewWillAppear
+            .flatMap { _ -> AnyPublisher<[ArticleDataByWeek], Never> in
+                return Future<[ArticleDataByWeek], NetworkError> { promise in
+                    Task {
+                        do {
+                            let articlesData = try await self.getArticleListByCategory(categoryString: self.categoryString)
+                            self.articleListData = articlesData
+                            promise(.success(articlesData))
+                        } catch {
+                            guard let error = error as? NetworkError else { return }
+                            promise(.failure(error))
+                        }
+                    }
+                }
+                .catch { error in
+                    self.handleError(error: error)
+                    let empty: [ArticleDataByWeek] = []
+                    return Just(empty)
+                }
+                .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+        
+        
+        let bookmark = input.bookmarkTapped
+            .flatMap { (isSelected: Bool, indexPath: IndexPath) -> AnyPublisher<String, Never> in
+                return Future<String, NetworkError> { promise in
+                    Task {
+                        do {
+                            guard let articleId = self.articleListData?[indexPath.row].articleId
+                            else { return }
+                            try await self.bookmarkArticle(articleId: articleId, isSelected: isSelected)
+                        } catch {
+                            promise(.failure(error as! NetworkError))
+                        }
+                    }
+                }.catch { error in
+                    self.handleError(error: error)
+                    return Just(error.description)
+                }
+                .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+        
+        
+        
+        input.articleCellTapped
+            .sink { [weak self] indexPath in
+                guard let self,
+                      let articleId = self.articleListData?[indexPath.row].articleId
+                else { return }
+                
+                self.navigationSubject.send(.article(articleId: articleId))
+            }
+            .store(in: &cancelBag)
+        
+        input.backButtonTapped
+            .sink { _ in
+                self.navigationSubject.send(.backButton)
+            }
+            .store(in: &cancelBag)
+        
+        return Output(articles: articleDatas, bookmarkCompleted: bookmark)
+    }
+    
+    func setCategoryTitle(title: String) {
+        self.categoryString = title
+        
+    }
+    
+}
+
+extension ArticleListByCategoryViewModelImpl {
+    private func getArticleListByCategory(categoryString: String?) async throws -> [ArticleDataByWeek] {
+        guard let categoryString else { return [] }
+        return try await manager.getArticleListByCategory(categoryString: categoryString).articleData
+    }
+    
+    private func handleError(error: NetworkError) {
+        switch error {
+        case .unAuthorizedError:
+            self.navigationSubject.send(.expire)
+        default:
+            self.errorSubject.send(error)
+        }
+    }
+    
+    private func bookmarkArticle(articleId: Int, isSelected: Bool) async throws {
+        try await self.manager.postBookmark(model: BookmarkRequest(articleId: articleId,
+                                                                      bookmarkRequestStatus: isSelected))
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleCategoryViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleCategoryViewControllerable.swift
@@ -7,6 +7,4 @@
 
 import UIKit
 
-protocol ArticleCategoryViewControllerable where Self: UIViewController {
-    var navigator: ArticleCategoryNavigation {get set}
-}
+protocol ArticleCategoryViewControllerable where Self: UIViewController {}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
@@ -9,6 +9,6 @@ import UIKit
 
 
 protocol ArticleControllerable where Self: UIViewController {
-    func setArticleId(id: Int?)
-    var adaptor: ArticleDetailModalNavigation { get set }
+//    func setArticleId(id: Int?)
+//    var adaptor: ArticleDetailModalNavigation { get set }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleControllerable.swift
@@ -8,7 +8,4 @@
 import UIKit
 
 
-protocol ArticleControllerable where Self: UIViewController {
-//    func setArticleId(id: Int?)
-//    var adaptor: ArticleDetailModalNavigation { get set }
-}
+protocol ArticleControllerable where Self: UIViewController {}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleListByCategoryViewControllerable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/ControllerableInterface/ArticleListByCategoryViewControllerable.swift
@@ -7,7 +7,4 @@
 
 import UIKit
 
-protocol ArticleListByCategoryViewControllerable where Self: UIViewController {
-    var navigator: ArticleListByCategoryNavigation { get set }
-    var categoryString: String? { get set }
-}
+protocol ArticleListByCategoryViewControllerable where Self: UIViewController {}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCategoryCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCategoryCoordinatorImpl.swift
@@ -28,7 +28,7 @@ final class ArticleCategoryCoordinatorImpl: ArticleCategoryCoordinator {
     
     func showArticleCategoryViewController() {
         let articleCategoryAdaptor = ArticleCategoryAdaptor(coordinator: self)
-        let articleCategoryViewController = factory.makeArticleCategoryViewController(navigator: articleCategoryAdaptor)
+        let articleCategoryViewController = factory.makeArticleCategoryViewController(coordinator: articleCategoryAdaptor)
         self.navigationController.pushViewController(articleCategoryViewController, animated: true)
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCategoryCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCategoryCoordinatorImpl.swift
@@ -27,8 +27,7 @@ final class ArticleCategoryCoordinatorImpl: ArticleCategoryCoordinator {
     }
     
     func showArticleCategoryViewController() {
-        let articleCategoryAdaptor = ArticleCategoryAdaptor(coordinator: self)
-        let articleCategoryViewController = factory.makeArticleCategoryViewController(coordinator: articleCategoryAdaptor)
+        let articleCategoryViewController = factory.makeArticleCategoryViewController(coordinator: self)
         self.navigationController.pushViewController(articleCategoryViewController, animated: true)
     }
     
@@ -44,8 +43,7 @@ final class ArticleCategoryCoordinatorImpl: ArticleCategoryCoordinator {
     }
     
     func showArticleListbyCategoryViewController(categoryName: String) {
-        let articleListbyCategoryViewController = factory.makeArticleListByCategoryViewController(coordinator: self)
-        articleListbyCategoryViewController.categoryString = categoryName
+        let articleListbyCategoryViewController = factory.makeArticleListByCategoryViewController(coordinator: self, categoryName: categoryName)
         self.navigationController.pushViewController(articleListbyCategoryViewController, animated: true)
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/ArticleCoordinatorImpl.swift
@@ -28,8 +28,8 @@ final class ArticleCoordinatorImpl: ArticleCoordinator {
     }
     
     func showArticleDetailViewController() {
-        let articleDetailViewController = factory.makeArticleDetailViewController(coordinator: self)
-        articleDetailViewController.setArticleId(id: articleId)
+        let articleDetailViewController = factory.makeArticleDetailViewController(coordinator: self, articleId: articleId)
+//        articleDetailViewController.setArticleId(id: articleId)
         articleDetailViewController.isModalInPresentation = true
         articleDetailViewController.modalPresentationStyle = .fullScreen
         navigationController.present(articleDetailViewController, animated: true)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekTableViewCell.swift
@@ -27,7 +27,7 @@ final class CurriculumArticleByWeekTableViewCell: UITableViewCell, TableViewCell
     private let articleTagLabel = LHLabel(type: .body4, color: .gray400)
     private let articleReadTimeLabel = LHLabel(type: .body4, color: .gray500)
     private let articleContentLabel = LHLabel(type: .body3R, color: .gray300, lines: 2)
-    private lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkSmall,
+    lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkSmall,
                                                           select: ImageLiterals.BookMark.activeBookmarkSmall)
     private let articleImageView = LHImageView(contentMode: .scaleToFill).makeRound(4).opacity(0.4)
     private let readTimeAndBookmarkView = LHView(color: .designSystem(.black)).makeRound(4).opacity(0.6)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumListByWeekData.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumListByWeekData.swift
@@ -7,12 +7,12 @@
 
 import UIKit
 
-struct CurriculumWeekData: AppData {
+struct CurriculumWeekData: Hashable, AppData {
     var articleData: [ArticleDataByWeek]
     let week: Int?
 }
 
-struct ArticleDataByWeek: AppData {
+struct ArticleDataByWeek: Hashable, AppData {
     let articleId: Int
     let articleTitle: String
     let articleImage: String

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleCategortFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleCategortFactoryImpl.swift
@@ -8,19 +8,35 @@
 import Foundation
 
 struct ArticleCategortFactoryImpl: ArticleCategortFactory {
-    func makeArticleCategoryViewModel(cooridnator: ArticleCategoryNavigation) -> any ArticleCategoryViewModel & ArticleCategoryViewModelPresentable {
-        return ArticleCategoryViewModelImpl(navigator: cooridnator)
+    
+    
+    func makeArticleListByCategoryViewModel(cooridnator: ArticleCategoryCoordinator) -> any ArticleListByCategoryViewModel & ArticleListByCategoryViewModelPresentable {
+        let adaptor = self.makeArticleCategoryAdaptor(coordinator: cooridnator)
+        
+        let apiService = APIService()
+        let bookmarkServiceImpl = BookmarkServiceImpl(apiService: apiService)
+        let articleServiceImpl = ArticleServiceImpl(apiService: apiService)
+        let manager = ArticleListByCategoryMangerImpl(articleService: articleServiceImpl, bookmarkService: bookmarkServiceImpl)
+     
+        return ArticleListByCategoryViewModelImpl(navigator: adaptor, manager: manager)
+    }
+    
+    func makeArticleCategoryViewModel(cooridnator: ArticleCategoryCoordinator) -> any ArticleCategoryViewModel & ArticleCategoryViewModelPresentable {
+        let adaptor = self.makeArticleCategoryAdaptor(coordinator: cooridnator)
+        return ArticleCategoryViewModelImpl(navigator: adaptor)
     }
     
     func makeArticleCategoryAdaptor(coordinator: ArticleCategoryCoordinator) -> EntireArticleCategoryNavigation {
         return ArticleCategoryAdaptor(coordinator: coordinator)
     }
     
-    func makeArticleListByCategoryViewController(coordinator: ArticleCategoryCoordinator) -> ArticleListByCategoryViewControllerable {
-        return ArticleListByCategoryViewController(manager: ArticleListByCategoryMangerImpl(articleService: ArticleServiceImpl(apiService: APIService()), bookmarkService: BookmarkServiceImpl(apiService: APIService())), navigator: self.makeArticleCategoryAdaptor(coordinator: coordinator))
+    func makeArticleListByCategoryViewController(coordinator: ArticleCategoryCoordinator, categoryName: String) -> ArticleListByCategoryViewControllerable {
+        let viewModel = self.makeArticleListByCategoryViewModel(cooridnator: coordinator)
+        viewModel.setCategoryTitle(title: categoryName)
+        return ArticleListByCategoryViewController(viewModel: viewModel)
     }
     
-    func makeArticleCategoryViewController(coordinator: ArticleCategoryNavigation) -> ArticleCategoryViewControllerable {
+    func makeArticleCategoryViewController(coordinator: ArticleCategoryCoordinator) -> ArticleCategoryViewControllerable {
         let viewModel = self.makeArticleCategoryViewModel(cooridnator: coordinator)
         return ArticleCategoryViewController(viewModel: viewModel)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleCategortFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleCategortFactoryImpl.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 struct ArticleCategortFactoryImpl: ArticleCategortFactory {
+    func makeArticleCategoryViewModel(cooridnator: ArticleCategoryNavigation) -> any ArticleCategoryViewModel & ArticleCategoryViewModelPresentable {
+        return ArticleCategoryViewModelImpl(navigator: cooridnator)
+    }
+    
     func makeArticleCategoryAdaptor(coordinator: ArticleCategoryCoordinator) -> EntireArticleCategoryNavigation {
         return ArticleCategoryAdaptor(coordinator: coordinator)
     }
@@ -16,7 +20,8 @@ struct ArticleCategortFactoryImpl: ArticleCategortFactory {
         return ArticleListByCategoryViewController(manager: ArticleListByCategoryMangerImpl(articleService: ArticleServiceImpl(apiService: APIService()), bookmarkService: BookmarkServiceImpl(apiService: APIService())), navigator: self.makeArticleCategoryAdaptor(coordinator: coordinator))
     }
     
-    func makeArticleCategoryViewController(navigator: ArticleCategoryNavigation) -> ArticleCategoryViewControllerable {
-        return ArticleCategoryViewController(navigator: navigator)
+    func makeArticleCategoryViewController(coordinator: ArticleCategoryNavigation) -> ArticleCategoryViewControllerable {
+        let viewModel = self.makeArticleCategoryViewModel(cooridnator: coordinator)
+        return ArticleCategoryViewController(viewModel: viewModel)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleFactoryImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryImpl/ArticleFactoryImpl.swift
@@ -8,19 +8,26 @@
 import Foundation
 
 struct ArticleFactoryImpl: ArticleFactory {
-    func makeAdaptor(coordinator: ArticleCoordinator) -> EntireArticleAdaptor {
-        let adaptor = ArticleAdaptor(coordinator: coordinator)
-        return adaptor
-    }
     
-    func makeArticleDetailViewController(coordinator: ArticleCoordinator) -> ArticleControllerable {
+    func makeArticleViewModel(coordinator: ArticleCoordinator) -> any ArticleDetailViewModel & ArticleDetailViewModelPresentable {
         let adaptor = self.makeAdaptor(coordinator: coordinator)
         let apiService = APIService()
         let bookmarkService = BookmarkServiceImpl(apiService: apiService)
         let articleService = ArticleServiceImpl(apiService: apiService)
         let manager = ArticleDetailManagerImpl(articleService: articleService,
                                                             bookmarkService: bookmarkService)
-        let articleDetailViewController = ArticleDetailViewController(manager: manager, adaptor: adaptor)
+        return ArticleDetailViewModelImpl(adaptor: adaptor, manager: manager)
+    }
+    
+    func makeAdaptor(coordinator: ArticleCoordinator) -> EntireArticleAdaptor {
+        let adaptor = ArticleAdaptor(coordinator: coordinator)
+        return adaptor
+    }
+    
+    func makeArticleDetailViewController(coordinator: ArticleCoordinator, articleId: Int) -> ArticleControllerable {
+        let viewModel = self.makeArticleViewModel(coordinator: coordinator)
+        viewModel.setArticleId(id: articleId)
+        let articleDetailViewController = ArticleDetailViewController(viewModel: viewModel)
         return articleDetailViewController
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleCategortFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleCategortFactory.swift
@@ -8,8 +8,13 @@
 import Foundation
 
 protocol ArticleCategortFactory {
-    func makeArticleCategoryViewModel(cooridnator: ArticleCategoryNavigation) -> any ArticleCategoryViewModel & ArticleCategoryViewModelPresentable
+    func makeArticleListByCategoryViewModel(cooridnator: ArticleCategoryCoordinator) -> any ArticleListByCategoryViewModel & ArticleListByCategoryViewModelPresentable
+    
+    func makeArticleCategoryViewModel(cooridnator: ArticleCategoryCoordinator) -> any ArticleCategoryViewModel & ArticleCategoryViewModelPresentable
+    
     func makeArticleCategoryAdaptor(coordinator: ArticleCategoryCoordinator) -> EntireArticleCategoryNavigation
-    func makeArticleListByCategoryViewController(coordinator: ArticleCategoryCoordinator) -> ArticleListByCategoryViewControllerable
-    func makeArticleCategoryViewController(coordinator: ArticleCategoryNavigation) -> ArticleCategoryViewControllerable
+    
+    func makeArticleListByCategoryViewController(coordinator: ArticleCategoryCoordinator, categoryName: String) -> ArticleListByCategoryViewControllerable
+    
+    func makeArticleCategoryViewController(coordinator: ArticleCategoryCoordinator) -> ArticleCategoryViewControllerable
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleCategortFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleCategortFactory.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 protocol ArticleCategortFactory {
+    func makeArticleCategoryViewModel(cooridnator: ArticleCategoryNavigation) -> any ArticleCategoryViewModel & ArticleCategoryViewModelPresentable
     func makeArticleCategoryAdaptor(coordinator: ArticleCategoryCoordinator) -> EntireArticleCategoryNavigation
     func makeArticleListByCategoryViewController(coordinator: ArticleCategoryCoordinator) -> ArticleListByCategoryViewControllerable
-    func makeArticleCategoryViewController(navigator: ArticleCategoryNavigation) -> ArticleCategoryViewControllerable
+    func makeArticleCategoryViewController(coordinator: ArticleCategoryNavigation) -> ArticleCategoryViewControllerable
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleFactory.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Factory/FactoryInterface/ArticleFactory.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol ArticleFactory {
+    func makeArticleViewModel(coordinator: ArticleCoordinator) -> any ArticleDetailViewModel & ArticleDetailViewModelPresentable
     func makeAdaptor(coordinator: ArticleCoordinator) -> EntireArticleAdaptor
-    func makeArticleDetailViewController(coordinator: ArticleCoordinator) -> ArticleControllerable
+    func makeArticleDetailViewController(coordinator: ArticleCoordinator, articleId: Int) -> ArticleControllerable
 }


### PR DESCRIPTION
## 🌱 작업한 내용

- ArticleListByCategory 기존의 DataSource에서 DiffableDataSource로 변경
- ArticleListByCategory MVC-C에서 MVVM-C로 리팩토링

## 🌱 PR Point
### DiffableDataSourceItem으로 매핑
DiffableDataSource를 생성하기 위해서는 Hashable한 Item타입을 지정해주어야합니다.
```swift
enum ArticleListByCategoryItem: Hashable {
    case article(data: ArticleDataByWeek)
}
```
따라서 위와 같은 enum을 구성하고 그 연관값으로 데이터를 전달합니다.
각 각의 Item은 Hashable하고, 모두 구분이 가능해야하기 때문에 이 때 전달되는 데이터는 `[]`, 배열의 형태가 아닌 단일값에 대한 타입(`CategoryImage`)입니다.

하지만 네트워크를 통해서 얻는 결과는 배열형태의 `[CategoryImage]`입니다. 따라서 이를 Item으로 넣어주기 위해서는 각각의 배열 요소를 위에서 생성한 enum의 category case의 연관값으로 바꿔주어야합니다. 이를 위해서 아래와 같이 코드를 작성하였습니다.

```swift
func applySnapshot(articleDatas: [ArticleDataByWeek]) {
        var snapshot = NSDiffableDataSourceSnapshot<ArticleListByCategorySection, ArticleListByCategoryItem>()
    snapshot.appendSections([.article])

    let items = articleDatas.map {
        return ArticleListByCategoryItem.article(data: $0)
    }

    snapshot.appendItems(items, toSection: .article)
    self.datasource.apply(snapshot)
}
```


## 📮 관련 이슈

- Resolved: #175 
