### PR TITLE
[REFACTOR] Tabbar Coordinator리팩터링(메서드분리)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		C034EDE02ADE3A4A00AD6FF3 /* LionHeart_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8482A5525C800F0DB19 /* LionHeart_iOSTests.swift */; };
 		C034EE1E2ADE44E200AD6FF3 /* ArticleCategoryAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C034EE1D2ADE44E200AD6FF3 /* ArticleCategoryAdaptor.swift */; };
 		C034EE202ADE450600AD6FF3 /* ArticleCategoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C034EE1F2ADE450600AD6FF3 /* ArticleCategoryCoordinator.swift */; };
+		C03FCD422B0DD11C00C4EA0D /* UITabbarItem+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03FCD412B0DD11C00C4EA0D /* UITabbarItem+.swift */; };
 		C04BE3AD2ADD4F5D001967B5 /* TodayCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04BE3AC2ADD4F5D001967B5 /* TodayCoordinatorImpl.swift */; };
 		C04BE3AF2ADD4F7F001967B5 /* TodayAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04BE3AE2ADD4F7F001967B5 /* TodayAdaptor.swift */; };
 		C065F0032ADBD2270094912C /* AuthFactoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C065F0022ADBD2270094912C /* AuthFactoryImpl.swift */; };
@@ -518,6 +519,7 @@
 		C034EDDD2ADE2F3500AD6FF3 /* ArticleListByCategoryViewControllerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListByCategoryViewControllerable.swift; sourceTree = "<group>"; };
 		C034EE1D2ADE44E200AD6FF3 /* ArticleCategoryAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryAdaptor.swift; sourceTree = "<group>"; };
 		C034EE1F2ADE450600AD6FF3 /* ArticleCategoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryCoordinator.swift; sourceTree = "<group>"; };
+		C03FCD412B0DD11C00C4EA0D /* UITabbarItem+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabbarItem+.swift"; sourceTree = "<group>"; };
 		C04BE3AC2ADD4F5D001967B5 /* TodayCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C04BE3AE2ADD4F7F001967B5 /* TodayAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayAdaptor.swift; sourceTree = "<group>"; };
 		C065F0022ADBD2270094912C /* AuthFactoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFactoryImpl.swift; sourceTree = "<group>"; };
@@ -955,6 +957,7 @@
 				D34280762A66B90C00DA1499 /* UILabelPadding.swift */,
 				4A81C2902ACC7DC80056E815 /* UICollectionViewCell+.swift */,
 				B52C6BB32AF8AE1D008E3B99 /* Combine+.swift */,
+				C03FCD412B0DD11C00C4EA0D /* UITabbarItem+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2179,6 +2182,7 @@
 				C09A33222A62D46300B40770 /* LHToast.swift in Sources */,
 				C003CC572ADA4FEB00AFFAAC /* UserState.swift in Sources */,
 				B59BFD352ADBBAE6005D2D81 /* CurriculumControllerable.swift in Sources */,
+				C03FCD422B0DD11C00C4EA0D /* UITabbarItem+.swift in Sources */,
 				B53BA2022A68717B006F9BFB /* LoadingIndicator.swift in Sources */,
 				C0856B7F2ABFCBF20026D9F8 /* ArticleListByCategoryMangerImpl.swift in Sources */,
 				C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UITabbarItem+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UITabbarItem+.swift
@@ -1,0 +1,27 @@
+//
+//  UITabbarItem+.swift
+//  LionHeart-iOS
+//
+//  Created by uiskim on 2023/11/22.
+//
+
+import UIKit
+
+extension UITabBarItem {
+    enum TabType {
+        case today, category, curriculum, challenge
+        
+        var tabbarElements: (title: String, image: UIImage?, tag: Int) {
+            switch self {
+            case .today: return (title: "투데이", image: UIImage.assetImage(.home), tag: 0)
+            case .category: return (title: "탐색", image: UIImage.assetImage(.search), tag: 1)
+            case .curriculum: return (title: "커리큘럼", image: UIImage.assetImage(.curriculum), tag: 2)
+            case .challenge: return (title: "챌린지", image: UIImage.assetImage(.challenge), tag: 3)
+            }
+        }
+    }
+    
+    static func makeTabItem(_ type: TabType) -> UITabBarItem {
+        return UITabBarItem(title: type.tabbarElements.title, image: type.tabbarElements.image, tag: type.tabbarElements.tag)
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TabbarCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TabbarCoordinatorImpl.swift
@@ -24,40 +24,55 @@ final class TabbarCoordinatorImpl: Coordinator {
     
     func showTabbarController() {
         let tabbarController = TabBarViewController()
-        
         let todayNavigationController = UINavigationController()
-        let todayCoordinator = TodayCoordinatorImpl(navigationController: todayNavigationController, factory: TodayFactoryImpl())
-        todayCoordinator.parentCoordinator = parentCoordinator
-        todayNavigationController.tabBarItem = UITabBarItem(title: "투데이", image: .assetImage(.home), tag: 0)
-        
         let articleCategoryNavigationController = UINavigationController()
-        let articleCategoryCoordinator = ArticleCategoryCoordinatorImpl(navigationController: articleCategoryNavigationController, factory: ArticleCategortFactoryImpl())
-        articleCategoryCoordinator.parentCoordinator = parentCoordinator
-        articleCategoryNavigationController.tabBarItem = UITabBarItem(title: "탐색", image: .assetImage(.search), tag: 1)
-        
         let curriculumNavigationController = UINavigationController()
-        let curriculumCoordinator = CurriculumCoordinatorImpl(
-            navigationController: curriculumNavigationController,
-            factory: CurriculumFactoryImpl()
-        )
-        curriculumNavigationController.tabBarItem = UITabBarItem(title: "커리큘럼", image: .assetImage(.curriculum), tag: 2)
-        curriculumCoordinator.parentCoordinator = parentCoordinator
-        
         let challengeNavigationController = UINavigationController()
-        let challengeCoordinator = ChallengeCoordinatorImpl(navigationController: challengeNavigationController, factory: ChallengeFactoryImpl())
-        challengeCoordinator.parentCoordinator = parentCoordinator
-        challengeNavigationController.tabBarItem = UITabBarItem(title: "챌린지", image: .assetImage(.challenge), tag: 3)
+        
+        startTodayArticleFlow(todayNavigationController)
+        startArticleCategoryFlow(articleCategoryNavigationController)
+        startCurriculumFlow(curriculumNavigationController)
+        startChallengeFlow(challengeNavigationController)
         
         tabbarController.viewControllers = [todayNavigationController, articleCategoryNavigationController, curriculumNavigationController, challengeNavigationController]
         
         navigationController.viewControllers.removeAll()
         navigationController.pushViewController(tabbarController, animated: true)
         navigationController.isNavigationBarHidden = true
-        parentCoordinator?.children = [todayCoordinator, articleCategoryCoordinator, curriculumCoordinator, challengeCoordinator]
-        
+    }
+}
+
+private extension TabbarCoordinatorImpl {
+    
+    func startTodayArticleFlow(_ navi: UINavigationController) {
+        let todayCoordinator = TodayCoordinatorImpl(navigationController: navi, factory: TodayFactoryImpl())
+        todayCoordinator.parentCoordinator = parentCoordinator
+        navi.tabBarItem = .makeTabItem(.today)
+        self.parentCoordinator?.children.append(todayCoordinator)
         todayCoordinator.showTodayViewController()
+    }
+    
+    func startArticleCategoryFlow(_ navi: UINavigationController) {
+        let articleCategoryCoordinator = ArticleCategoryCoordinatorImpl(navigationController: navi, factory: ArticleCategortFactoryImpl())
+        articleCategoryCoordinator.parentCoordinator = parentCoordinator
+        navi.tabBarItem = .makeTabItem(.category)
+        self.parentCoordinator?.children.append(articleCategoryCoordinator)
         articleCategoryCoordinator.showArticleCategoryViewController()
+    }
+    
+    func startCurriculumFlow(_ navi: UINavigationController) {
+        let curriculumCoordinator = CurriculumCoordinatorImpl(navigationController: navi, factory: CurriculumFactoryImpl())
+        navi.tabBarItem = .makeTabItem(.curriculum)
+        curriculumCoordinator.parentCoordinator = parentCoordinator
+        self.parentCoordinator?.children.append(curriculumCoordinator)
         curriculumCoordinator.showCurriculumViewController()
+    }
+
+    func startChallengeFlow(_ navi: UINavigationController) {
+        let challengeCoordinator = ChallengeCoordinatorImpl(navigationController: navi, factory: ChallengeFactoryImpl())
+        challengeCoordinator.parentCoordinator = parentCoordinator
+        navi.tabBarItem = .makeTabItem(.challenge)
+        self.parentCoordinator?.children.append(challengeCoordinator)
         challengeCoordinator.showChallengeViewController()
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TabbarCoordinatorImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Coordinator/CoordinatorImpl/TabbarCoordinatorImpl.swift
@@ -29,10 +29,10 @@ final class TabbarCoordinatorImpl: Coordinator {
         let curriculumNavigationController = UINavigationController()
         let challengeNavigationController = UINavigationController()
         
-        startTodayArticleFlow(todayNavigationController)
-        startArticleCategoryFlow(articleCategoryNavigationController)
-        startCurriculumFlow(curriculumNavigationController)
-        startChallengeFlow(challengeNavigationController)
+        startTodayArticleFlow(todayNavigationController, from: parentCoordinator)
+        startArticleCategoryFlow(articleCategoryNavigationController, from: parentCoordinator)
+        startCurriculumFlow(curriculumNavigationController, from: parentCoordinator)
+        startChallengeFlow(challengeNavigationController, from: parentCoordinator)
         
         tabbarController.viewControllers = [todayNavigationController, articleCategoryNavigationController, curriculumNavigationController, challengeNavigationController]
         
@@ -44,35 +44,35 @@ final class TabbarCoordinatorImpl: Coordinator {
 
 private extension TabbarCoordinatorImpl {
     
-    func startTodayArticleFlow(_ navi: UINavigationController) {
+    func startTodayArticleFlow(_ navi: UINavigationController, from parent: Coordinator?) {
         let todayCoordinator = TodayCoordinatorImpl(navigationController: navi, factory: TodayFactoryImpl())
-        todayCoordinator.parentCoordinator = parentCoordinator
+        todayCoordinator.parentCoordinator = parent
         navi.tabBarItem = .makeTabItem(.today)
-        self.parentCoordinator?.children.append(todayCoordinator)
+        parent?.children.append(todayCoordinator)
         todayCoordinator.showTodayViewController()
     }
     
-    func startArticleCategoryFlow(_ navi: UINavigationController) {
+    func startArticleCategoryFlow(_ navi: UINavigationController, from parent: Coordinator?) {
         let articleCategoryCoordinator = ArticleCategoryCoordinatorImpl(navigationController: navi, factory: ArticleCategortFactoryImpl())
-        articleCategoryCoordinator.parentCoordinator = parentCoordinator
+        articleCategoryCoordinator.parentCoordinator = parent
         navi.tabBarItem = .makeTabItem(.category)
-        self.parentCoordinator?.children.append(articleCategoryCoordinator)
+        parent?.children.append(articleCategoryCoordinator)
         articleCategoryCoordinator.showArticleCategoryViewController()
     }
     
-    func startCurriculumFlow(_ navi: UINavigationController) {
+    func startCurriculumFlow(_ navi: UINavigationController, from parent: Coordinator?) {
         let curriculumCoordinator = CurriculumCoordinatorImpl(navigationController: navi, factory: CurriculumFactoryImpl())
         navi.tabBarItem = .makeTabItem(.curriculum)
-        curriculumCoordinator.parentCoordinator = parentCoordinator
-        self.parentCoordinator?.children.append(curriculumCoordinator)
+        curriculumCoordinator.parentCoordinator = parent
+        parent?.children.append(curriculumCoordinator)
         curriculumCoordinator.showCurriculumViewController()
     }
 
-    func startChallengeFlow(_ navi: UINavigationController) {
+    func startChallengeFlow(_ navi: UINavigationController, from parent: Coordinator?) {
         let challengeCoordinator = ChallengeCoordinatorImpl(navigationController: navi, factory: ChallengeFactoryImpl())
-        challengeCoordinator.parentCoordinator = parentCoordinator
+        challengeCoordinator.parentCoordinator = parent
         navi.tabBarItem = .makeTabItem(.challenge)
-        self.parentCoordinator?.children.append(challengeCoordinator)
+        parent?.children.append(challengeCoordinator)
         challengeCoordinator.showChallengeViewController()
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/TabBar/TabBarViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/TabBar/TabBarViewController.swift
@@ -10,10 +10,24 @@ import UIKit
 
 import SnapKit
 
-final class TabBarViewController: UITabBarController {
+protocol Tabbar {
+    var load: ((UINavigationController) -> ())? { get set }
+    var todayArticleTapSelected: ((UINavigationController) -> ())? { get set }
+    var searchTapSelected: ((UINavigationController) -> ())? { get set }
+    var curriculumTapSelected: ((UINavigationController) -> ())? { get set }
+    var challengeTapSelected: ((UINavigationController) -> ())? { get set }
+}
+
+final class TabBarViewController: UITabBarController, Tabbar {
+    var load: ((UINavigationController) -> ())?
+    var todayArticleTapSelected: ((UINavigationController) -> ())?
+    var searchTapSelected: ((UINavigationController) -> ())?
+    var curriculumTapSelected: ((UINavigationController) -> ())?
+    var challengeTapSelected: ((UINavigationController) -> ())?
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        delegate = self
         let tabBarAppearance = UITabBarAppearance()
         tabBarAppearance.backgroundColor = .black
         let tabBarItemAppearance = UITabBarItemAppearance()
@@ -33,5 +47,21 @@ final class TabBarViewController: UITabBarController {
         super.viewDidLayoutSubviews()
         tabBar.frame.size.height = 100
         tabBar.frame.origin.y = view.frame.height - 100
+    }
+}
+
+extension TabBarViewController: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let controller = viewControllers?[selectedIndex] as? UINavigationController else { return }
+        switch selectedIndex {
+        case 0:
+            todayArticleTapSelected?(controller)
+        case 1:
+            
+        case 2:
+        case 3:
+        default:
+            break
+        }
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/TabBar/TabBarViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/TabBar/TabBarViewController.swift
@@ -30,14 +30,19 @@ private extension UITabBarController {
     func makeAppearance() -> UITabBarAppearance {
         let tabBarAppearance = UITabBarAppearance()
         tabBarAppearance.backgroundColor = .black
+        let tabBarItemAppearance = self.makeTabbarItemApperance()
+        tabBarAppearance.inlineLayoutAppearance = tabBarItemAppearance
+        tabBarAppearance.stackedLayoutAppearance = tabBarItemAppearance
+        tabBarAppearance.compactInlineLayoutAppearance = tabBarItemAppearance
+        return tabBarAppearance
+    }
+    
+    func makeTabbarItemApperance() -> UITabBarItemAppearance {
         let tabBarItemAppearance = UITabBarItemAppearance()
         tabBarItemAppearance.normal.iconColor = .gray
         tabBarItemAppearance.selected.iconColor = .white
         tabBarItemAppearance.normal.titleTextAttributes = [ .foregroundColor : UIColor.gray, .font : UIFont.systemFont(ofSize: 9)]
         tabBarItemAppearance.selected.titleTextAttributes = [ .foregroundColor : UIColor.white, .font : UIFont.systemFont(ofSize: 9, weight: .bold)]
-        tabBarAppearance.inlineLayoutAppearance = tabBarItemAppearance
-        tabBarAppearance.stackedLayoutAppearance = tabBarItemAppearance
-        tabBarAppearance.compactInlineLayoutAppearance = tabBarItemAppearance
-        return tabBarAppearance
+        return tabBarItemAppearance
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/TabBar/TabBarViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/TabBar/TabBarViewController.swift
@@ -10,35 +10,11 @@ import UIKit
 
 import SnapKit
 
-protocol Tabbar {
-    var load: ((UINavigationController) -> ())? { get set }
-    var todayArticleTapSelected: ((UINavigationController) -> ())? { get set }
-    var searchTapSelected: ((UINavigationController) -> ())? { get set }
-    var curriculumTapSelected: ((UINavigationController) -> ())? { get set }
-    var challengeTapSelected: ((UINavigationController) -> ())? { get set }
-}
+final class TabBarViewController: UITabBarController {
 
-final class TabBarViewController: UITabBarController, Tabbar {
-    var load: ((UINavigationController) -> ())?
-    var todayArticleTapSelected: ((UINavigationController) -> ())?
-    var searchTapSelected: ((UINavigationController) -> ())?
-    var curriculumTapSelected: ((UINavigationController) -> ())?
-    var challengeTapSelected: ((UINavigationController) -> ())?
-    
     public override func viewDidLoad() {
         super.viewDidLoad()
-        delegate = self
-        let tabBarAppearance = UITabBarAppearance()
-        tabBarAppearance.backgroundColor = .black
-        let tabBarItemAppearance = UITabBarItemAppearance()
-        tabBarItemAppearance.normal.iconColor = .gray
-        tabBarItemAppearance.selected.iconColor = .white
-        tabBarItemAppearance.normal.titleTextAttributes = [ .foregroundColor : UIColor.gray, .font : UIFont.systemFont(ofSize: 9)]
-        tabBarItemAppearance.selected.titleTextAttributes = [ .foregroundColor : UIColor.white, .font : UIFont.systemFont(ofSize: 9, weight: .bold)]
-        tabBarAppearance.inlineLayoutAppearance = tabBarItemAppearance
-        tabBarAppearance.stackedLayoutAppearance = tabBarItemAppearance
-        tabBarAppearance.compactInlineLayoutAppearance = tabBarItemAppearance
-        
+        let tabBarAppearance = self.makeAppearance()
         self.tabBar.standardAppearance = tabBarAppearance
         self.tabBar.scrollEdgeAppearance = tabBarAppearance
     }
@@ -50,18 +26,18 @@ final class TabBarViewController: UITabBarController, Tabbar {
     }
 }
 
-extension TabBarViewController: UITabBarControllerDelegate {
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        guard let controller = viewControllers?[selectedIndex] as? UINavigationController else { return }
-        switch selectedIndex {
-        case 0:
-            todayArticleTapSelected?(controller)
-        case 1:
-            
-        case 2:
-        case 3:
-        default:
-            break
-        }
+private extension UITabBarController {
+    func makeAppearance() -> UITabBarAppearance {
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.backgroundColor = .black
+        let tabBarItemAppearance = UITabBarItemAppearance()
+        tabBarItemAppearance.normal.iconColor = .gray
+        tabBarItemAppearance.selected.iconColor = .white
+        tabBarItemAppearance.normal.titleTextAttributes = [ .foregroundColor : UIColor.gray, .font : UIFont.systemFont(ofSize: 9)]
+        tabBarItemAppearance.selected.titleTextAttributes = [ .foregroundColor : UIColor.white, .font : UIFont.systemFont(ofSize: 9, weight: .bold)]
+        tabBarAppearance.inlineLayoutAppearance = tabBarItemAppearance
+        tabBarAppearance.stackedLayoutAppearance = tabBarItemAppearance
+        tabBarAppearance.compactInlineLayoutAppearance = tabBarItemAppearance
+        return tabBarAppearance
     }
 }


### PR DESCRIPTION
## [#171] REFACTOR : Tabbar Coordinator리팩터링(메서드분리)

## 🌱 작업한 내용
- 기존 TabbarCoordinator가 하나의 메서드에 모든 VC를 생성하고 설정해주는 로직이 모여있어 메서드분리를 진행해줬습니다
- 작업을 진행하면서 reference type의 이점을 살려 pure function으로 메서드를 분리하고 구현했습니다
- 간단한 작업이어서 pr은 작업한 내용정도로 마무리하겠습니다

## 🌱 작업한 코드
tabbarController내부에 정의될 vc를 메서드를 통해서 분리해 구현해줬습니다
```swift
func startTodayArticleFlow(_ navi: UINavigationController, from parent: Coordinator?) {
    let todayCoordinator = TodayCoordinatorImpl(navigationController: navi, factory: TodayFactoryImpl())
    todayCoordinator.parentCoordinator = parent
    navi.tabBarItem = .makeTabItem(.today)
    parent?.children.append(todayCoordinator)
    todayCoordinator.showTodayViewController()
}
```
coordinator가 AnyObject를 채택하는 프로토콜이라 reference를 참조해서 child에 append를 해도 괜찮을거같아서 메서드의 인자로 coordiantor프로토콜타입을 받아서 하나의 reference를 참조하도록 구현했습니다

기존 tabbarItem이 하드코딩 되어있던 부분이 있어서 enum을 활용해서 간단하게 구현했습니다

```swift
extension UITabBarItem {
    enum TabType {
        case today, category, curriculum, challenge
        
        var tabbarElements: (title: String, image: UIImage?, tag: Int) {
            switch self {
            case .today: return (title: "투데이", image: UIImage.assetImage(.home), tag: 0)
            case .category: return (title: "탐색", image: UIImage.assetImage(.search), tag: 1)
            case .curriculum: return (title: "커리큘럼", image: UIImage.assetImage(.curriculum), tag: 2)
            case .challenge: return (title: "챌린지", image: UIImage.assetImage(.challenge), tag: 3)
            }
        }
    }
    
    static func makeTabItem(_ type: TabType) -> UITabBarItem {
        return UITabBarItem(title: type.tabbarElements.title, image: type.tabbarElements.image, tag: type.tabbarElements.tag)
    }
}
```
## 📮 관련 이슈

- Resolved: #171
