### PR TITLE
[REFACTOR] runloop, cell binding방식, 토스트메세지, loadingView 적용

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
@@ -72,14 +72,9 @@ final class ChallengeViewController: UIViewController, ChallengeViewControllerab
         let output = viewModel.transform(input: input)
         output.viewWillAppearSubject
             .receive(on: RunLoop.main)
-            .sink { [weak self] result in
-                switch result {
-                case .success(let data):
-                    self?.configureData(data)
-                    self?.hideLoading()
-                case .failure(let error):
-                    print(error.description)
-                }
+            .sink { [weak self] data in
+                self?.configureData(data)
+                self?.hideLoading()
             }
             .store(in: &cancelBag)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewModel/ChallengeViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewModel/ChallengeViewModel.swift
@@ -19,5 +19,5 @@ struct ChallengeViewModelInput {
 }
 
 struct ChallengeViewModelOutput {
-    let viewWillAppearSubject: AnyPublisher<Result<ChallengeData, NetworkError>, Never>
+    let viewWillAppearSubject: AnyPublisher<ChallengeData, Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/ViewController/MyPageViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/ViewController/MyPageViewController.swift
@@ -54,6 +54,7 @@ final class MyPageViewController: UIViewController, MyPageControllerable {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.showLoading()
         viewWillAppearSubject.send(())
     }
     
@@ -72,6 +73,7 @@ final class MyPageViewController: UIViewController, MyPageControllerable {
 private extension MyPageViewController {
     func setUI() {
         view.backgroundColor = .designSystem(.background)
+        resignButton.backgroundColor = .designSystem(.lionRed)
     }
     
     func setHierarchy() {
@@ -79,7 +81,7 @@ private extension MyPageViewController {
     }
     
     func setLayout() {
-        resignButton.backgroundColor = .designSystem(.lionRed)
+        
         navigtaionBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
@@ -128,6 +130,7 @@ private extension MyPageViewController {
             .sink { [weak self] in
                 self?.setTableViewHeader($0.profileData)
                 self?.dataSource.makeList($0.appSettingData, $0.customerServiceData)
+                self?.hideLoading()
             }
             .store(in: &cancelBag)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/CompleteOnboardingViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/CompleteOnboardingViewController.swift
@@ -65,6 +65,7 @@ final class CompleteOnboardingViewController: UIViewController, CompleteOnboardi
         let output = viewModel.transform(input: input)
         
         output.fetalNickname
+            .receive(on: RunLoop.main)
             .sink { [weak self] fetalNickname in
                 guard let fetalNickname = fetalNickname else { return }
                 self?.titleLabel.text = "\(fetalNickname)님\n반가워요!"
@@ -74,6 +75,7 @@ final class CompleteOnboardingViewController: UIViewController, CompleteOnboardi
     
     private func bindInput() {
         startButton.tapPublisher
+            .receive(on: RunLoop.main)
             .sink { [weak self] in
                 self?.startButtonTapped.send(())
             }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -65,15 +65,25 @@ final class OnboardingViewController: UIViewController, OnboardingViewController
         let input = OnboardingViewModelInput(pregenacy: pregenacy, fetalNickname: fetalNickname, backButtonTapped: backButtonTapped, nextButtonTapped: nextButtonTapped)
         let output = viewModel.transform(input: input)
         
+        output.userSigningSubject
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
+                $0 ? self?.hideLoading() : self?.showLoading()
+            }
+            .store(in: &cancelBag)
+        
         output.fetalButtonState
+            .receive(on: RunLoop.main)
             .sink { [ weak self ] in self?.nextButton.isHidden = $0 }
             .store(in: &cancelBag)
         
         output.pregenacyButtonState
+            .receive(on: RunLoop.main)
             .sink { [ weak self ] in self?.nextButton.isHidden = $0 }
             .store(in: &cancelBag)
         
         output.onboardingFlow
+            .receive(on: RunLoop.main)
             .sink { [weak self] in
                 if $0 == .toCompleteOnboarding {
                     self?.nextButton.isUserInteractionEnabled = false

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -26,4 +26,5 @@ struct OnboardingViewModelOutput {
     let fetalButtonState: AnyPublisher<Bool, Never>
     let onboardingFlow: AnyPublisher<OnbardingFlowType, Never>
     let signUpSubject: AnyPublisher<String, Never>
+    let userSigningSubject: AnyPublisher<Bool, Never>
 }


### PR DESCRIPTION
## [#189] REFACTOR :  runloop, cell binding방식, 토스트메세지, loadingView 적용

## 🌱 작업한 내용
### 2차리팩 완료전에 맡은 뷰를 최종적으로  점검했습니다
- ChallengeVC 점검
- MyPageVC 점검
- TodayVC 점검
- OnboardingVC 점검

## 🌱 PR Point
### Onboarding에서의 loadingView추가
네트워크 통신이 시작되고나면 lodingview가 화면에 표시되고 네트워크통신이끝나면 lodingview를 없애줍니다 버튼자체가 비동기적으로 호출되기에 호출시점에 처리를하기위해 해당 관련 stream을 따로 만들었습니다
```swift
let signUpSubject = signUpSubject
    .flatMap { _ -> AnyPublisher<String, Never> in
        return Future<String, NetworkError> { promise  in
            Task {
                do {
                    self.userSigningSubject.send(.start)
                    let passingData = UserOnboardingModel(kakaoAccessToken: self.kakaoAccessToken, pregnacny: input.pregenacy.value.pregnancy, fetalNickname: input.fetalNickname.value.fetalNickname)
                    try await self.manager.signUp(type: .kakao, onboardingModel: passingData)
                    self.userSigningSubject.send(.end)
                    self.navigatorSubject.send(.onboardingCompleted(passingData))
                } catch {
                    promise(.failure(error as! NetworkError))
                }
            }
        }
        .catch { error in
            Just(error.description)
        }
        .eraseToAnyPublisher()
    }
    .eraseToAnyPublisher()
```
그리고 네트워킹 시작하는 시점에 새로만든 stream에 start라는 type을 넘겨주고 네트워킹이끝나면 end라는 type을 넘겨줍니다 

```swift
output.userSigningSubject
    .receive(on: RunLoop.main)
    .sink { [weak self] in
        switch $0 {
        case .start:
            self?.showLoading()
        case .end:
            self?.hideLoading()
        }
    }
    .store(in: &cancelBag)
```
button action에 따른 네트워킹이 시작되고 끝나면 해당 stream이 그 type을 받아서 type별로 lodingview를 관리합니다

## 📮 관련 이슈

- Resolved: #189 
