### PR TITLE
[REFACTOR] Runloop, cell binding방식, 토스트메세지, loadingView 적용 (#190)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Global/Literals/NameSpace.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Literals/NameSpace.swift
@@ -18,3 +18,20 @@ enum SocialLoginType: String {
     case kakao = "KAKAO"
     case apple = "APPLE"
 }
+
+enum BookmarkCompleted {
+    case save
+    case delete
+    case failure
+    
+    var message: String {
+        switch self {
+        case .save:
+            return "북마크 저장에 성공했습니다."
+        case .delete:
+            return "북마크 삭제에 성공했습니다."
+        case .failure:
+            return "북마크 요청에 실패했습니다."
+        }
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHToast/LHToast.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHToast/LHToast.swift
@@ -17,7 +17,7 @@ final class LHToast {
         window.subviews
             .filter { $0 is LHToastView }
             .forEach { $0.removeFromSuperview() }
-//        window.addSubview(toastView)
+        window.addSubview(toastView)
         
         toastView.snp.makeConstraints { make in
             if isTabBar {

--- a/LionHeart-iOS/LionHeart-iOS/Global/UserDefault/UserDefaultToken.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UserDefault/UserDefaultToken.swift
@@ -11,6 +11,7 @@ import Foundation
 struct UserDefaultToken: AppData, Codable {
     var refreshToken: String?
     var accessToken: String?
+    var kakaoToken: String?
     let fcmToken: String?
     
     var isExistJWT: Bool {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleDetail/Cells/ThumnailTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleDetail/Cells/ThumnailTableViewCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Combine
 
 import SnapKit
 
@@ -15,9 +16,11 @@ final class ThumnailTableViewCell: UITableViewCell, TableViewCellRegisterDequeue
     private let gradientImageView = LHImageView(in: ImageLiterals.Curriculum.gradient, contentMode: .scaleAspectFill)
     private let thumbnailImageView = LHImageView(contentMode: .scaleAspectFill)
     private let imageCaptionLabel = LHLabel(type: .body4, color: .gray500)
-    lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkBig, select: ImageLiterals.BookMark.activeBookmarkBig)
+    private lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkBig, select: ImageLiterals.BookMark.activeBookmarkBig)
 
-//    var bookmarkButtonDidTap: ((Bool) -> Void)?
+    var bookmarkSubject = PassthroughSubject<Void, Never>()
+    var cancelBag = Set<AnyCancellable>()
+    
     var inputData: ArticleBlockData? {
         didSet {
             configureCell(inputData)
@@ -44,6 +47,7 @@ final class ThumnailTableViewCell: UITableViewCell, TableViewCellRegisterDequeue
     }
 
     override func prepareForReuse() {
+        cancelBag.removeAll()
         self.thumbnailImageView.image = nil
     }
 }
@@ -95,11 +99,11 @@ private extension ThumnailTableViewCell {
     }
     
     func setAddTarget() {
-//        bookMarkButton.addButtonAction { [weak self] _ in
-//            guard let self else { return }
-//            self.isSelected.toggle()
-//            self.bookmarkButtonDidTap?(self.isSelected)
-//        }
+        bookMarkButton.addButtonAction { [weak self] _ in
+            guard let self else { return }
+            self.bookMarkButton.isSelected.toggle()
+            self.bookmarkSubject.send(())
+        }
     }
 }
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleDetail/ViewController/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleDetail/ViewController/ArticleDetailViewController.swift
@@ -89,21 +89,22 @@ final class ArticleDetailViewController: UIViewController, ArticleControllerable
             .receive(on: RunLoop.main)
             .sink { [weak self] article in
                 guard let self else { return }
-                self.hideLoading()
-                
                 self.setDatasource(blockTypes: article.blockTypes,
                                    isBookMarked: article.isMarked)
                 self.applySnapshot(article.blockTypes)
+                self.hideLoading()
             }
             .store(in: &cancelBag)
         
         output.bookmarkCompleted
-            .sink { str in
-                print(str)
+            .receive(on: RunLoop.main)
+            .sink { message in
+                LHToast.show(message: message)
             }
             .store(in: &cancelBag)
         
         output.scrollToTopButtonTapped
+            .receive(on: RunLoop.main)
             .sink { _ in
                 let indexPath = IndexPath(row: 0, section: 0)
                 self.articleTableView.scrollToRow(at: indexPath, at: .top, animated: true)
@@ -123,17 +124,16 @@ extension ArticleDetailViewController {
                 cell.inputData = thumbnailModel
                 cell.selectionStyle = .none
                 
-                cell.bookMarkButton.tapPublisher
+                cell.bookmarkSubject
                     .sink { [weak self] _ in
-                        cell.isMarked?.toggle()
                         self?.bookmarkButtonTapped.send(())
                     }
-                    .store(in: &self.cancelBag)
+                    .store(in: &cell.cancelBag)
 
                 if isBookMarked {
-                    cell.isMarked = isBookMarked
+                    cell.isSelected = isBookMarked
                 } else {
-                    cell.isMarked = isMarked
+                    cell.isSelected = isMarked
                 }
                 cell.setThumbnailImageView()
                 return cell

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleListByCategory/ViewController/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleListByCategory/ViewController/ArticleListByCategoryViewController.swift
@@ -98,11 +98,11 @@ extension ArticleListByCategoryViewController {
                 cell.inputData = articleData
                 cell.selectionStyle = .none
                 
-                cell.bookMarkButton.tapPublisher
-                    .sink { [weak self] _ in
-                        self?.bookmarkTapped.send((isSelected: cell.isSelected, indexPath: indexPath))
-                    }
-                    .store(in: &self.cancelBag)
+//                cell.bookMarkButton.tapPublisher
+//                    .sink { [weak self] _ in
+//                        self?.bookmarkTapped.send((isSelected: cell.isSelected, indexPath: indexPath))
+//                    }
+//                    .store(in: &self.cancelBag)
                 return cell
             }
         })

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/Cell/CurriculumArticleByWeekTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/Cell/CurriculumArticleByWeekTableViewCell.swift
@@ -20,15 +20,17 @@ final class CurriculumArticleByWeekTableViewCell: UITableViewCell, TableViewCell
             configureData(inputData)
         }
     }
-
-//    var bookMarkButtonTapped: ((Bool, IndexPath) -> Void)?
+    
+    var cancelBag = Set<AnyCancellable>()
+    
+    var bookmarkSubject = PassthroughSubject<Bool, Never>()
     
     private let tableViewCellWholeView = UIView()
     private let articleTitleLabel = LHLabel(type: .head3, color: .white)
     private let articleTagLabel = LHLabel(type: .body4, color: .gray400)
     private let articleReadTimeLabel = LHLabel(type: .body4, color: .gray500)
     private let articleContentLabel = LHLabel(type: .body3R, color: .gray300, lines: 2)
-    lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkSmall,
+    private lazy var bookMarkButton = LHToggleImageButton(normal: ImageLiterals.BookMark.inactiveBookmarkSmall,
                                                           select: ImageLiterals.BookMark.activeBookmarkSmall)
     private let articleImageView = LHImageView(contentMode: .scaleToFill).makeRound(4).opacity(0.4)
     private let readTimeAndBookmarkView = LHView(color: .designSystem(.black)).makeRound(4).opacity(0.6)
@@ -40,11 +42,16 @@ final class CurriculumArticleByWeekTableViewCell: UITableViewCell, TableViewCell
         setUI()
         setHierarchy()
         setLayout()
+        bindInput()
     }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        cancelBag.removeAll()
     }
 }
 
@@ -112,9 +119,11 @@ private extension CurriculumArticleByWeekTableViewCell {
         }
     }
     
-    func getIndexPath() -> IndexPath? {
-        guard let superView = self.superview as? UITableView else { return nil }
-        return superView.indexPath(for: self)
+    func bindInput() {
+        self.bookMarkButton.addButtonAction { [weak self] in
+            $0.isSelected.toggle()
+            self?.bookmarkSubject.send($0.isSelected)
+        }
     }
     
     func configureData(_ inputData: ArticleDataByWeek) {
@@ -130,6 +139,5 @@ private extension CurriculumArticleByWeekTableViewCell {
         articleContentLabel.lineBreakStrategy = .pushOut
         articleContentLabel.lineBreakMode = .byTruncatingTail
         bookMarkButton.isSelected = inputData.isArticleBookmarked
-
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/ViewController/CurriculumListWeekViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/ViewController/CurriculumListWeekViewController.swift
@@ -48,6 +48,7 @@ final class CurriculumListWeekViewController: UIViewController, CurriculumArticl
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        self.showLoading()
         self.viewWillAppearSubject.send(.none)
     }
     
@@ -83,13 +84,14 @@ final class CurriculumListWeekViewController: UIViewController, CurriculumArticl
                 self?.setTableView(input: $0.data)
                 self?.navigationBar.setCurriculumWeek(week: $0.data.week ?? 0)
                 self?.headerView.buttonHidden(left: $0.leftButtonHidden, right: $0.rightButtonHidden)
+                self?.hideLoading()
             }
             .store(in: &cancelBag)
         
         output.bookMarkCompleted
             .receive(on: RunLoop.main)
             .sink { message in
-                print(message)
+                LHToast.show(message: message)
             }
             .store(in: &cancelBag)
     }
@@ -100,12 +102,11 @@ final class CurriculumListWeekViewController: UIViewController, CurriculumArticl
             case .article(let weekData):
                 let cell = CurriculumArticleByWeekTableViewCell.dequeueReusableCell(to: tableView)
                 
-                cell.bookMarkButton.tapPublisher
-                    .sink { _ in
-                        cell.isSelected.toggle()
-                        self.bookmarkButtonTapped.send((indexPath: indexPath, isSelected: !cell.isSelected))
+                cell.bookmarkSubject
+                    .sink { isSelected in
+                        self.bookmarkButtonTapped.send((indexPath: indexPath, isSelected: isSelected))
                     }
-                    .store(in: &self.cancelBag)
+                    .store(in: &cell.cancelBag)
                     
                 
                 cell.inputData = weekData

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/ViewModel/CurriculumListWeekViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/ViewModel/CurriculumListWeekViewModelImpl.swift
@@ -70,8 +70,15 @@ final class CurriculumListWeekViewModelImpl: CurriculumListWeekViewModel {
                         do {
                             guard let articleId = self.curriculumWeekData?.articleData[indexPath.row].articleId
                             else { return }
+                            
                             try await self.bookmarkArticle(articleId: articleId, isSelected: isSelected)
-                            promise(.success("북마크 저장에 성공했습니다."))
+                            
+                            if isSelected {
+                                promise(.success(BookmarkCompleted.save.message))
+                            } else {
+                                promise(.success(BookmarkCompleted.delete.message))
+                            }
+//                            promise(.success(BookmarkCompleted.success.message))
                         } catch {
                             promise(.failure(error as! NetworkError))
                         }
@@ -79,7 +86,7 @@ final class CurriculumListWeekViewModelImpl: CurriculumListWeekViewModel {
                 }
                 .catch { error in
                     self.errorSubject.send(error)
-                    return Just("북마크 저장이 실패했습니다.")
+                    return Just(BookmarkCompleted.failure.message)
                 }
                 .eraseToAnyPublisher()
             })

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewModel/CurriculumViewViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewModel/CurriculumViewViewModelImpl.swift
@@ -19,19 +19,12 @@ final class CurriculumViewViewModelImpl: CurriculumViewViewModel, CurriculumView
     private let navigator: CurriculumNavigation
     private let manager: CurriculumManager
     
-    private var isFirstPresented: Bool = true
     private var curriculumViewDatas = CurriculumMonthData.dummy()
     private var userInfoData: UserInfoData?
     
     private let navigationSubject = PassthroughSubject<FlowType, Never>()
     private let errorSubject = PassthroughSubject<NetworkError, Never>()
     private var cancelBag = Set<AnyCancellable>()
-    
-//    {
-//        didSet {
-//            configureUserInfoData()
-//        }
-//    }
     
     init(navigator: CurriculumNavigation, manager: CurriculumManager) {
         self.navigator = navigator
@@ -81,15 +74,6 @@ final class CurriculumViewViewModelImpl: CurriculumViewViewModel, CurriculumView
             }
             .store(in: &cancelBag)
         
-//        let toggleButtonTapped = input.toggleButtonTapped
-//            .map { [weak self] indexPath -> [CurriculumMonthData] in
-//                guard let self = self else { return [] }
-//                let previousWeekDatas = self.curriculumViewDatas[indexPath.section].weekDatas[indexPath.row]
-//                self.curriculumViewDatas[indexPath.section].weekDatas[indexPath.row].isExpanded = !previousWeekDatas.isExpanded
-//                return self.curriculumViewDatas
-//            }
-//            .eraseToAnyPublisher()
-        
         let curriculumMonth = input.viewWillAppear
             .flatMap { _ -> AnyPublisher<(userInfo: UserInfoData, monthData: [CurriculumMonthData]), Never> in
                 return Future<(userInfo: UserInfoData, monthData: [CurriculumMonthData]), NetworkError> { promise in
@@ -110,52 +94,16 @@ final class CurriculumViewViewModelImpl: CurriculumViewViewModel, CurriculumView
                 .eraseToAnyPublisher()
             }
             .eraseToAnyPublisher()
-        
-//        
-//        
-//        
-//        
-//            .map {
-//                return CurriculumMonthData.dummy()
-//            }
-//            .eraseToAnyPublisher()
-        
-        
-            
-        
-        
+
         return Output(curriculumMonth: curriculumMonth)
     }
     
 }
 
 extension CurriculumViewViewModelImpl {
-    func scrollToUserWeek() {
-        guard let userInfoData else { return }
-        let userWeek = userInfoData.userWeekInfo
-        let weekPerMonth = 4
-        let desireSection = userWeek == 40 ? (userWeek/weekPerMonth)-2 : (userWeek/weekPerMonth)-1
-        let desireRow = (userWeek % weekPerMonth)
-        let indexPath = IndexPath(row: desireRow, section: desireSection)
-        let weekDataRow = userWeek == 40 ? desireRow + 4 : desireRow
-        curriculumViewDatas[desireSection].weekDatas[weekDataRow].isExpanded = true
-        
-        
-//        self.curriculumTableView.reloadData()
-//        self.curriculumTableView.scrollToRow(at: indexPath, at: .top, animated: false)
-        
-    }
     
     func getCurriculumData() async throws -> UserInfoData {
         return try await manager.getCurriculumServiceInfo()
-//        Task {
-//            do {
-//                userInfoData =
-//            } catch {
-////                guard let error = error as? NetworkError else { return }
-////                handleError(error)
-//            }
-//        }
     }
     
 }


### PR DESCRIPTION
## 🌱 작업한 내용

- CurriculumView
- CurriculumListWeekView
- ArticleDetail
- Login

각각의 뷰에 대해서 메인 스레드 관리, cell binding 방식 통일, 북마크 저장, 삭제, 요청 실패 토스트 메시지 추가했습니다.

ViewController의 bind메서드 내에서 UI에 데이터 바인딩을 하는 코드가 메인스레드에서 돌아가게끔 receive(on:) 메서드를 활용했습니다.
```swift
output.articleData
    .receive(on: RunLoop.main)
    .sink { ... }
```

Cell binding에 대한 내용은 https://github.com/Team-LionHeart/LionHeart-iOS/pull/187 해당 PR에서 자세히 설명해두었습니다!

## 📸 스크린샷
![Simulator Screen Recording - iPhone 13 mini - 2023-11-24 at 16 24 50](https://github.com/Team-LionHeart/LionHeart-iOS/assets/60292150/41fef98e-7e42-4d7d-8313-344ba495cd9f)


## 📮 관련 이슈

- Resolved: #190
