### PR TITLE
[REFACTOR] Runloop, cell binding방식, 토스트메세지, loadingView 적용 (#191)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHToast/LHToast.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHToast/LHToast.swift
@@ -17,7 +17,7 @@ final class LHToast {
         window.subviews
             .filter { $0 is LHToastView }
             .forEach { $0.removeFromSuperview() }
-//        window.addSubview(toastView)
+        window.addSubview(toastView)
         
         toastView.snp.makeConstraints { make in
             if isTabBar {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleCategory/ViewController/ArticleCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleCategory/ViewController/ArticleCategoryViewController.swift
@@ -45,6 +45,8 @@ final class ArticleCategoryViewController: UIViewController, ArticleCategoryView
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        showLoading()
         viewWillAppearSubject.send(())
     }
     
@@ -80,10 +82,12 @@ final class ArticleCategoryViewController: UIViewController, ArticleCategoryView
         let output = viewModel.transform(input: input)
         
         output.categoryTitle
+            .receive(on: RunLoop.main)
             .sink { [weak self] categoryImages in
                 guard let self else { return }
                 self.setDataSource()
                 self.applySnapshot(categoryImages: categoryImages)
+                self.hideLoading()
             }
             .store(in: &cancelBag)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleListByCategory/ViewController/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/ArticleListByCategory/ViewController/ArticleListByCategoryViewController.swift
@@ -71,8 +71,10 @@ final class ArticleListByCategoryViewController: UIViewController, ArticleListBy
                                                         bookmarkTapped: bookmarkTapped,
                                                         articleCellTapped: articleCellTapped)
         let output = viewModel.transform(input: input)
+        // 북마크 토스트 메시지 띄우기
         output.bookmarkCompleted
-            .sink { message in
+            .receive(on: RunLoop.main)
+            .sink { [weak self] message in
                 print(message)
             }
             .store(in: &cancelBag)
@@ -98,11 +100,12 @@ extension ArticleListByCategoryViewController {
                 cell.inputData = articleData
                 cell.selectionStyle = .none
                 
-//                cell.bookMarkButton.tapPublisher
-//                    .sink { [weak self] _ in
-//                        self?.bookmarkTapped.send((isSelected: cell.isSelected, indexPath: indexPath))
-//                    }
-//                    .store(in: &self.cancelBag)
+                cell.bookmarkSubject
+                    .sink { isSelected in
+                        self.bookmarkTapped.send((isSelected: isSelected, indexPath: indexPath))
+                    }
+                    .store(in: &cell.cancelBag)
+                
                 return cell
             }
         })

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkListCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkListCollectionViewCell.swift
@@ -24,7 +24,7 @@ final class BookmarkListCollectionViewCell: UICollectionViewCell,
     private let bottomLineView = LHUnderLine(lineColor: .gray800)
     
     let bookmarkButtonTapped = PassthroughSubject<IndexPath, Never>()
-    private var cancelBag = Set<AnyCancellable>()
+    var cancelBag = Set<AnyCancellable>()
     
     var inputData: ArticleSummaries? {
         didSet {
@@ -51,6 +51,11 @@ final class BookmarkListCollectionViewCell: UICollectionViewCell,
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancelBag.removeAll()
     }
 }
 

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewController/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewController/BookmarkViewController.swift
@@ -50,8 +50,8 @@ final class BookmarkViewController: UIViewController, BookmarkViewControllerable
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        showLoading()
         
+        showLoading()
         viewWillAppear.send(())
     }
     
@@ -72,9 +72,9 @@ private extension BookmarkViewController {
     }
     
     func setLayout() {
-        navigationBar.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.leading.trailing.equalToSuperview()
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalToSuperview()
         }
         
         bookmarkCollectionView.snp.makeConstraints {
@@ -105,14 +105,18 @@ private extension BookmarkViewController {
         let output = viewModel.transform(input: input)
         
         output.viewWillAppear
+            .receive(on: RunLoop.main)
             .sink { [weak self] data in
                 self?.updateDiffableDataSource(sectionModel: data)
+                self?.hideLoading()
             }
             .store(in: &cancelBag)
         
         output.bookmarkButtonTapped
+            .receive(on: RunLoop.main)
             .sink { [weak self] data in
                 self?.updateDiffableDataSource(sectionModel: data)
+                LHToast.show(message: "북마크 해제")
             }
             .store(in: &cancelBag)
     }
@@ -165,10 +169,11 @@ private extension BookmarkViewController {
                     cell.inputData = bookmarkAppData
                     
                     cell.bookmarkButtonTapped
+                        .receive(on: RunLoop.main)
                         .sink { [weak self] indexPath in
                             self?.bookmarkButtonTapped.send(indexPath)
                         }
-                        .store(in: &self.cancelBag)
+                        .store(in: &cell.cancelBag)
                 }
                 return cell
             }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewController/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewController/BookmarkViewController.swift
@@ -114,9 +114,9 @@ private extension BookmarkViewController {
         
         output.bookmarkButtonTapped
             .receive(on: RunLoop.main)
-            .sink { [weak self] data in
+            .sink { [weak self] (data, message) in
                 self?.updateDiffableDataSource(sectionModel: data)
-                LHToast.show(message: "북마크 해제")
+                LHToast.show(message: message)
             }
             .store(in: &cancelBag)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewModel/BookViewModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewModel/BookViewModel.swift
@@ -21,5 +21,5 @@ struct BookmarkViewModelInput {
 
 struct BookmarkViewModelOutput {
     let viewWillAppear: AnyPublisher<BookmarkAppData, Never>
-    let bookmarkButtonTapped: AnyPublisher<BookmarkAppData, Never>
+    let bookmarkButtonTapped: AnyPublisher<(model: BookmarkAppData, message: String), Never>
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewModel/BookmarkViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewModel/BookmarkViewModelImpl.swift
@@ -76,13 +76,13 @@ final class BookmarkViewModelImpl: BookmarkViewModel, BookmarkViewModelPresentab
             .eraseToAnyPublisher()
         
         let bookmarkButtonTapped = input.bookmarkButtonTapped
-            .flatMap { indexPath -> AnyPublisher<BookmarkAppData, Never> in
-                return Future<BookmarkAppData, NetworkError> { promise in
+            .flatMap { indexPath -> AnyPublisher<(model: BookmarkAppData, message: String), Never> in
+                return Future<(model: BookmarkAppData, message: String), NetworkError> { promise in
                     Task {
                         do {
                             try await self.manager.postBookmark(model: .init(articleId: self.bookmarkAppData.articleSummaries[indexPath.item].articleID, bookmarkRequestStatus: !self.bookmarkAppData.articleSummaries[indexPath.item].bookmarked))
                             self.bookmarkAppData.articleSummaries.remove(at: indexPath.item)
-                            promise(.success(self.bookmarkAppData))
+                            promise(.success((model: self.bookmarkAppData, message: BookmarkCompleted.delete.message)))
                         } catch {
                             promise(.failure(error as! NetworkError))
                         }
@@ -90,7 +90,7 @@ final class BookmarkViewModelImpl: BookmarkViewModel, BookmarkViewModelPresentab
                 }
                 .catch { error in
                     self.errorSubject.send(error)
-                    return Just(BookmarkAppData.empty)
+                    return Just((model: BookmarkAppData.empty, message: BookmarkCompleted.failure.message))
                 }
                 .eraseToAnyPublisher()
             }


### PR DESCRIPTION
## 🌱 작업한 내용

- 북마크, 주차별 아티클, 주차별 아티클 카테고리 VC 2차 리팩터링 코드 정리했습니다.

## 🌱 PR Point

### viewcontroller에서의 UI에 데이터 바인딩 하는 코드들은 메인 스레드에서 동작하도록 receive  메서드를 추가했습니다.
```swift
        output.viewWillAppear
            .receive(on: RunLoop.main)
            .sink { [weak self] data in
                self?.updateDiffableDataSource(sectionModel: data)
                self?.hideLoading()
            }
            .store(in: &cancelBag)
        
        output.bookmarkButtonTapped
            .receive(on: RunLoop.main)
            .sink { [weak self] (data, message) in
                self?.updateDiffableDataSource(sectionModel: data)
                LHToast.show(message: message)
            }
            .store(in: &cancelBag)
````


### 북마크 삭제시, 해당 상황에 맞는 토스트 메시지를 넘겨받도록 viewModel의 output 스트림에서 AppData 타입과 toast message에 띄워줄 string 값도 추가로 보내도록 수정했습니다.

```swift
let bookmarkButtonTapped = input.bookmarkButtonTapped
            .flatMap { indexPath -> AnyPublisher<(model: BookmarkAppData, message: String), Never> in
                return Future<(model: BookmarkAppData, message: String), NetworkError> { promise in
                    Task {
                        do {
                            try await self.manager.postBookmark(model: .init(articleId: self.bookmarkAppData.articleSummaries[indexPath.item].articleID, bookmarkRequestStatus: !self.bookmarkAppData.articleSummaries[indexPath.item].bookmarked))
                            self.bookmarkAppData.articleSummaries.remove(at: indexPath.item)
                            promise(.success((model: self.bookmarkAppData, message: BookmarkCompleted.delete.message)))
                        } catch {
                            promise(.failure(error as! NetworkError))
                        }
                    }
                }
                .catch { error in
                    self.errorSubject.send(error)
                    return Just((model: BookmarkAppData.empty, message: BookmarkCompleted.failure.message))
                }
                .eraseToAnyPublisher()
            }
            .eraseToAnyPublisher()
```


## 📸 스크린샷

|    북마크    |   
| :-------------: | 
| ![Simulator Screen Recording - iPhone 13 mini - 2023-11-24 at 16 51 07](https://github.com/Team-LionHeart/LionHeart-iOS/assets/86944161/d8a9a54a-5ee2-4825-aad8-5dd7709cc401)| 

## 📮 관련 이슈

- Resolved: #191 
