### PR TITLE
[TEST] API Unit Test 관련 파일들 추가 (#195)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -120,6 +120,9 @@
 		B59BFD3F2ADBBF2B005D2D81 /* CurriculumFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD3E2ADBBF2B005D2D81 /* CurriculumFactory.swift */; };
 		B59BFD412ADBBFB2005D2D81 /* MyPageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD402ADBBFB2005D2D81 /* MyPageFactory.swift */; };
 		B59BFD432ADBBFF5005D2D81 /* ArticleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BFD422ADBBFF5005D2D81 /* ArticleFactory.swift */; };
+		B5BE51C12B15B8F100042EF3 /* ServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE51C02B15B8F100042EF3 /* ServiceTests.swift */; };
+		B5BE51C72B15C75F00042EF3 /* URLSessionStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE51C62B15C75F00042EF3 /* URLSessionStub.swift */; };
+		B5BE51C92B15CB9600042EF3 /* JSONLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE51C82B15CB9600042EF3 /* JSONLoader.swift */; };
 		B5C6A2B22A5DB0B10021BE5E /* ArticleDetailTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2B12A5DB0B10021BE5E /* ArticleDetailTableView.swift */; };
 		B5C6A2B42A5DB11A0021BE5E /* ThumnailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2B32A5DB11A0021BE5E /* ThumnailTableViewCell.swift */; };
 		B5C6A2B62A5DD5FE0021BE5E /* TitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6A2B52A5DD5FE0021BE5E /* TitleTableViewCell.swift */; };
@@ -476,6 +479,9 @@
 		B59BFD3E2ADBBF2B005D2D81 /* CurriculumFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumFactory.swift; sourceTree = "<group>"; };
 		B59BFD402ADBBFB2005D2D81 /* MyPageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageFactory.swift; sourceTree = "<group>"; };
 		B59BFD422ADBBFF5005D2D81 /* ArticleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleFactory.swift; sourceTree = "<group>"; };
+		B5BE51C02B15B8F100042EF3 /* ServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTests.swift; sourceTree = "<group>"; };
+		B5BE51C62B15C75F00042EF3 /* URLSessionStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionStub.swift; sourceTree = "<group>"; };
+		B5BE51C82B15CB9600042EF3 /* JSONLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONLoader.swift; sourceTree = "<group>"; };
 		B5C6A2B12A5DB0B10021BE5E /* ArticleDetailTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleDetailTableView.swift; sourceTree = "<group>"; };
 		B5C6A2B32A5DB11A0021BE5E /* ThumnailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumnailTableViewCell.swift; sourceTree = "<group>"; };
 		B5C6A2B52A5DD5FE0021BE5E /* TitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTableViewCell.swift; sourceTree = "<group>"; };
@@ -920,6 +926,9 @@
 		B532E8472A5525C800F0DB19 /* LionHeart-iOSTests */ = {
 			isa = PBXGroup;
 			children = (
+				B5BE51C32B15BD6200042EF3 /* URLSessionStub */,
+				B5BE51BB2B15B7B100042EF3 /* Today */,
+				B5BE51BA2B15B79C00042EF3 /* Challenge */,
 				B532E8482A5525C800F0DB19 /* LionHeart_iOSTests.swift */,
 			);
 			path = "LionHeart-iOSTests";
@@ -1426,6 +1435,94 @@
 				B598930A2A5BED0E00CE1FEB /* Font.swift */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		B5BE51BA2B15B79C00042EF3 /* Challenge */ = {
+			isa = PBXGroup;
+			children = (
+				B5BE51C52B15BDBD00042EF3 /* JSON */,
+				B5BE51BC2B15B80F00042EF3 /* ViewModelStub */,
+				B5BE51BF2B15B8C300042EF3 /* ServiceTests */,
+				B5BE51C22B15B8F600042EF3 /* ViewControllerTests */,
+			);
+			path = Challenge;
+			sourceTree = "<group>";
+		};
+		B5BE51BB2B15B7B100042EF3 /* Today */ = {
+			isa = PBXGroup;
+			children = (
+				B5BE51CD2B15CC5300042EF3 /* JSON */,
+				B5BE51CF2B15CC5B00042EF3 /* ServiceTests */,
+				B5BE51CE2B15CC5700042EF3 /* ViewModelStub */,
+				B5BE51D02B15CC5F00042EF3 /* ViewControllerTests */,
+			);
+			path = Today;
+			sourceTree = "<group>";
+		};
+		B5BE51BC2B15B80F00042EF3 /* ViewModelStub */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModelStub;
+			sourceTree = "<group>";
+		};
+		B5BE51BF2B15B8C300042EF3 /* ServiceTests */ = {
+			isa = PBXGroup;
+			children = (
+				B5BE51C02B15B8F100042EF3 /* ServiceTests.swift */,
+			);
+			path = ServiceTests;
+			sourceTree = "<group>";
+		};
+		B5BE51C22B15B8F600042EF3 /* ViewControllerTests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewControllerTests;
+			sourceTree = "<group>";
+		};
+		B5BE51C32B15BD6200042EF3 /* URLSessionStub */ = {
+			isa = PBXGroup;
+			children = (
+				B5BE51C82B15CB9600042EF3 /* JSONLoader.swift */,
+				B5BE51C62B15C75F00042EF3 /* URLSessionStub.swift */,
+			);
+			path = URLSessionStub;
+			sourceTree = "<group>";
+		};
+		B5BE51C52B15BDBD00042EF3 /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = JSON;
+			sourceTree = "<group>";
+		};
+		B5BE51CD2B15CC5300042EF3 /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = JSON;
+			sourceTree = "<group>";
+		};
+		B5BE51CE2B15CC5700042EF3 /* ViewModelStub */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModelStub;
+			sourceTree = "<group>";
+		};
+		B5BE51CF2B15CC5B00042EF3 /* ServiceTests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ServiceTests;
+			sourceTree = "<group>";
+		};
+		B5BE51D02B15CC5F00042EF3 /* ViewControllerTests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewControllerTests;
 			sourceTree = "<group>";
 		};
 		B5C6A2C32A5EF4AC0021BE5E /* DTO */ = {
@@ -2490,7 +2587,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5BE51C92B15CB9600042EF3 /* JSONLoader.swift in Sources */,
 				C034EDE02ADE3A4A00AD6FF3 /* LionHeart_iOSTests.swift in Sources */,
+				B5BE51C12B15B8F100042EF3 /* ServiceTests.swift in Sources */,
+				B5BE51C72B15C75F00042EF3 /* URLSessionStub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LionHeart-iOS/LionHeart-iOS/Network/Base/APIService.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Base/APIService.swift
@@ -11,9 +11,22 @@ protocol Requestable {
     func request<T: Decodable>(_ request: URLRequest) async throws -> T?
 }
 
+protocol LHURLSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: LHURLSession {}
+
 final class APIService: Requestable {
+    
+    private let session: LHURLSession
+    
+    init(session: LHURLSession = URLSession.shared) {
+        self.session = session
+    }
+    
     func request<T: Decodable>(_ request: URLRequest) async throws -> T? {
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let (data, _) = try await session.data(for: request)
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(BaseResponse<T>.self, from: data) else {
             throw NetworkError.jsonDecodingError

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/ViewModel/CurriculumListWeekViewModelImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/CurriculmumListWeek/ViewModel/CurriculumListWeekViewModelImpl.swift
@@ -78,7 +78,6 @@ final class CurriculumListWeekViewModelImpl: CurriculumListWeekViewModel {
                             } else {
                                 promise(.success(BookmarkCompleted.delete.message))
                             }
-//                            promise(.success(BookmarkCompleted.success.message))
                         } catch {
                             promise(.failure(error as! NetworkError))
                         }

--- a/LionHeart-iOS/LionHeart-iOSTests/Challenge/ServiceTests/ServiceTests.swift
+++ b/LionHeart-iOS/LionHeart-iOSTests/Challenge/ServiceTests/ServiceTests.swift
@@ -1,0 +1,35 @@
+//
+//  ServiceTests.swift
+//  LionHeart-iOSTests
+//
+//  Created by 김민재 on 11/28/23.
+//
+
+import XCTest
+
+final class ServiceTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/LionHeart-iOS/LionHeart-iOSTests/URLSessionStub/JSONLoader.swift
+++ b/LionHeart-iOS/LionHeart-iOSTests/URLSessionStub/JSONLoader.swift
@@ -1,0 +1,19 @@
+//
+//  JSONLoader.swift
+//  LionHeart-iOSTests
+//
+//  Created by 김민재 on 11/28/23.
+//
+
+import Foundation
+
+final class JSONLoader {
+
+    func load(fileName: String) -> URL {
+        let bundle = Bundle(for: Self.self)
+        guard let fileURL = bundle.url(forResource: fileName, withExtension: "json") else {
+            return URL(fileURLWithPath: "")
+        }
+        return fileURL
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOSTests/URLSessionStub/URLSessionStub.swift
+++ b/LionHeart-iOS/LionHeart-iOSTests/URLSessionStub/URLSessionStub.swift
@@ -1,0 +1,22 @@
+//
+//  URLSessionStub.swift
+//  LionHeart-iOSTests
+//
+//  Created by 김민재 on 11/28/23.
+//
+
+import Foundation
+@testable import LionHeart_iOS
+
+final class URLSessionStub: LHURLSession {
+    
+    private var data: Data?
+    
+    init(data: Data? = nil) {
+        self.data = data
+    }
+    
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        return (data ?? Data(), URLResponse())
+    }
+}


### PR DESCRIPTION
## 🌱 작업한 내용

- Unit Test 관련 파일들 

## 🌱 PR Point

# 커버리지 목표
```Ruby
ViewController당 커버리지 70% 이상
```
---

## Unit test 과정

async await을 통한 기존 네트워크 통신은 urlsession객체의 data라는 메서드를 호출함으로써 진행됩니다

좀더 자세히 말하면 singleton으로 URLSession객체를 생성해서 data라는 메서드를 호출하면 URLRequest를 통한 네트워크통신을 해서 그 결과인 data와 response를 return해주는 방식입니다

> 즉, urlsession객체는 data라는 메서드를 구현하고 있는 상황입니다
> 

실직적으로 서버와 네트워크 통신을 하는 매개체는 `data(for: URLRequest)`라는 메서드이기때문에 우리가 네트워크통신을했을때 우리가 원하는 데이터가 올것이라는 예측에 의한 Testing을 위해서는 이 data라는 메서드를 우리가 원하는 방식으로(실제 네트워킹을 하지 않는 방식으로)만들어줘야합니다.

기존에 사용하던 네트워킹 객체를 test에서 사용해야 그 객체내부에서의 네트워크 통신이 문제없다는것이 보장되기에 원래쓰던(실제로 네트워킹을 하는 방식)방식으로도 사용을 할 수 있어야하고 이를 위해 `protocol`을 사용합니다.

```swift
protocol LHURLSession {
    func data(for request: URLRequest) async throws -> (Data, URLResponse)
}
```

`LHURLSession`이라는 protocol은 data라는 메서드를 추상화하고 있고 `URLSession`과 `URLSessionStub`에 채택시키면 실제 URLSession이라는 객체도 data라는 메서드를 구현하고있을거고 우리가 이제 구현할 `URLSessionStub`도 data라는 메서드를 구현하고 있는 상태가 됩니다.

```swift
extension URLSession: LHURLSession {}
```

URLSession이 LHURLSession을 채택만해도 되는데 그  이유는 이미 data라는 메서드를 구현하고있기 때문입니다. URLSessionStub에서는 data를 구현 해줘야합니다.

```swift
import Foundation
@testable import LionHeart_iOS

final class URLSessionStub: LHURLSession {
    
    private var data: Data?
    
    init(data: Data? = nil) {
        self.data = data
    }
    
    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
        return (data ?? Data(), URLResponse())
    }
}
```
URLSessionStub의 init에 받기를 예상되는 데이터와 response 그리고 error를 넣어줍니다

URLSessionStub에 이미 받아올 데이터와 response 그리고 error를 넣어주고나서 datatask를 실행하는 이유는 네트워크(서버)에서의 문제를 배제하고 어떤특정 데이터가 들어왔다고 가정하는것(stub)이기때문에 해당 dataTask는 우리가 상상하는 상태의 값을 반환해줘야하기때문입니다.

```swift
final class APIService: Requestable {
    func request<T: Decodable>(_ request: URLRequest) async throws -> T? {
        let (data, _) = try await URLSession.shared.data(for: request)
        let decoder = JSONDecoder()
        guard let decodedData = try? decoder.decode(BaseResponse<T>.self, from: data) else {
            throw NetworkError.jsonDecodingError
        }
        
        let statusCode = decodedData.code
        guard !NetworkErrorCode.clientErrorCode.contains(statusCode) else {
            throw NetworkError.clientError(code: decodedData.code, message: decodedData.message)
        }

        guard !NetworkErrorCode.serverErrorCode.contains(statusCode) else {
            throw NetworkError.serverError
        }
        
        print("✨✨✨✨✨✨✨✨✨✨✨✨✨API호출성공✨✨✨✨✨✨✨✨✨✨✨✨✨")
        print(decodedData)
        return decodedData.data
    }
}
```

라이언하트의 네트워크 통신의 core한 layer인 APIService레이어를 보면 URLSession의 data를 실행하는 부분이 있는데 이부분을 LHURLSession프로토콜을 채택하는 객체를 외부에서 주입받아서 사용해야 dataTask의 역할을 URLSessionStub으로 완전히 대체할 수 있습니다

```swift
final class APIService: Requestable {
    private let session: LHURLSession
    
    init(session: LHURLSession = URLSession.shared) {
		    self.session = session
    }

    func request<T: Decodable>(_ request: URLRequest) async throws -> T? {
        let (data, _) = try await session.data(for: request)
        let decoder = JSONDecoder()
        guard let decodedData = try? decoder.decode(BaseResponse<T>.self, from: data) else {
            throw NetworkError.jsonDecodingError
        }
        
        let statusCode = decodedData.code
        guard !NetworkErrorCode.clientErrorCode.contains(statusCode) else {
            throw NetworkError.clientError(code: decodedData.code, message: decodedData.message)
        }

        guard !NetworkErrorCode.serverErrorCode.contains(statusCode) else {
            throw NetworkError.serverError
        }
        
        print("✨✨✨✨✨✨✨✨✨✨✨✨✨API호출성공✨✨✨✨✨✨✨✨✨✨✨✨✨")
        print(decodedData)
        return decodedData.data
    }
}
```

이렇게 바꿔주면 기본적으로는 네트워크 통신을 하는 URLSession객체가 기본적으로 들어가며 만약에 MockDataTask를 넣고싶다면 LHURLSession를 채택한 dataTask를 넣어주면 됩니다

그럼 MockURLSession을 하나 만들어봅시다

```swift
import Foundation
@testable import LionHeart_iOS

final class URLSessionStub: LHURLSession {
    
    private var data: Data?
    
    init(data: Data? = nil) {
        self.data = data
    }
    
    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
        return (data ?? Data(), URLResponse())
    }
}
```
현재 LionHeart는 API의 status code가 무조건 200이고 data내부의 code값으로 오류여부를 판단하기에 특정 case에 대한 네트워킹 test를 위한 개별 json 파일을 만들어야합니다

따라서 json파일을 xcode내부에서 만들고 해당 json파일을 Data형태로 만들어주는 객체가 필요하다고 판단했습니다

```swift
import Foundation

final class JSONLoader {
    
    func load(fileName: String) throws -> URL {
        let bundle = Bundle(for: Self.self)
        guard let fileURL = bundle.url(forResource: fileName, withExtension: "json") else {
             return URL(fileURLWithPath: "")
        }
        return fileURL
    }
}
```
Json파일을 xcode에서만들고(파일을 만들고 확장자를 .json 으로 만들어주셔야합니다)
```swift
let jsonLoader = JSONLoader()
let fileURL = try jsonLoader.load(fileName: 실제파일명)
data = try Data(contentsOf: fileURL)
```
그리고 JsonLoader객체를 만든 후 load메서드에 json파일명을 넣어주면 해당 파일이 URL형태로 변환되게 되고

`Data(contentsOf:_)`메서드를 통해서 data타입의 객체로 만들어줄수있습니다

해당 data를 `URLSessionStub`의 init에 넣어주면 네트워킹이 완료되었을때 Json파일의 내용이 담겨있는 Data객체를 얻을수있음을 보장하게됩니다

그리고나서 error코드에 따른 테스트나 실제값의 갯수, 값타입, decoding 성공 여부등을 테스트할수있게됩니다.

그렇게 data가 만들어졌다고 가정해보겠습니다.

```swift
func test_네트워킹에_성공하고_챌린지데이터가_있을때() async throws {
    let urlSession = URLSessionStub(data: `json파일을 통해 만든 data`)
    let apiService = APIService(session: urlSession)
    let request = NetworkRequest(...)
    let result = try await apiService.request(request)
    let expectation = ChallengeDataResponse(babyNickname: "땅땅이", day: 0, level: "level1", attendances: ["11/1"]) 
    XCTAssertEqual(result, expectation)
}
```

data와 url이 있고 주어졌다고 가정했을 때 위와같은 test code를 작성할 수 있습니다

## test 메서드 네이밍 규칙

- 메서드명은 test로 시작
- 띄어쓰기마다 _(언더바)
- 테스트 시 직관성을 위해 한글을 사용하기로 했습니다.

## 📮 관련 이슈

- Resolved: #195 
